### PR TITLE
Add support for OlSourceImageWMS to getLegendGraphicUrl method (for ol4)

### DIFF
--- a/src/MapUtil/MapUtil.js
+++ b/src/MapUtil/MapUtil.js
@@ -1,7 +1,7 @@
 import OlMap from 'ol/map';
 import OlProjection from 'ol/proj';
 import OlSourceTileWMS from 'ol/source/tilewms';
-import OlLayerTile from 'ol/layer/tile';
+import OlSourceImageWMS from 'ol/source/imagewms';
 import OlLayerGroup from 'ol/layer/group';
 import OlLayerBase from 'ol/layer/base';
 
@@ -300,15 +300,25 @@ export class MapUtil {
    * @return {String|undefined} The getLegendGraphicUrl.
    */
   static getLegendGraphicUrl(layer, extraParams) {
-    if (!(layer instanceof OlLayerBase)) {
-      Logger.error('Invalid input parameter for MapUtil.getLegendGraphicUrl.');
+    if (!layer) {
+      Logger.error('No layer passed to MapUtil.getLegendGraphicUrl.');
       return;
     }
 
-    if (layer instanceof OlLayerTile
-        && layer.getSource() instanceof OlSourceTileWMS) {
+    const source = layer.getSource();
+    if (!(layer instanceof OlLayerBase) || !source) {
+      Logger.error('Invalid layer passed to MapUtil.getLegendGraphicUrl.');
+      return;
+    }
+
+    const isTiledWMS = source instanceof OlSourceTileWMS;
+    const isImageWMS = source instanceof OlSourceImageWMS;
+
+    if (isTiledWMS || isImageWMS) {
       const source = layer.getSource();
-      const url = source.getUrls() ? source.getUrls()[0] : '';
+      const url = isTiledWMS ?
+        source.getUrls() ? source.getUrls()[0] : ''
+        : source.getUrl();
       const params = {
         LAYER: source.getParams().LAYERS,
         VERSION: '1.3.0',

--- a/src/MapUtil/MapUtil.spec.js
+++ b/src/MapUtil/MapUtil.spec.js
@@ -3,7 +3,9 @@
 import OlInteractionDragRotateAndZoom from 'ol/interaction/dragrotateandzoom';
 import OlInteractionDraw from 'ol/interaction/draw';
 import OlLayerTile from 'ol/layer/tile';
+import OlLayerImage from 'ol/layer/image';
 import OlSourceTileWMS from 'ol/source/tilewms';
+import OlSourceImageWMS from 'ol/source/imagewms';
 import OlSourceTileJson from 'ol/source/tilejson';
 import OlFeature from 'ol/feature';
 import OlGeomPoint from 'ol/geom/point';
@@ -465,6 +467,7 @@ describe('MapUtil', () => {
 
     let layer1;
     let layer2;
+    let layer3;
 
     beforeEach(() => {
       layer1 = new OlLayerTile({
@@ -475,7 +478,15 @@ describe('MapUtil', () => {
           serverType: 'geoserver'
         })
       });
-      layer2 = new OlLayerTile({
+      layer2 = new OlLayerImage({
+        name: 'OSM-WMS',
+        source: new OlSourceImageWMS({
+          url: 'https://ows.terrestris.de/osm-gray/service',
+          params: {'LAYERS': 'OSM-WMS', 'TILED': true},
+          serverType: 'geoserver'
+        })
+      });
+      layer3 = new OlLayerTile({
         name: 'Food insecurity',
         source: new OlSourceTileJson({
           url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
@@ -489,7 +500,7 @@ describe('MapUtil', () => {
       const legendUrl = MapUtil.getLegendGraphicUrl();
       expect(legendUrl).toBeUndefined();
       expect(logSpy).toHaveBeenCalled();
-      expect(logSpy).toHaveBeenCalledWith('Invalid input parameter for MapUtil.getLegendGraphicUrl.');
+      expect(logSpy).toHaveBeenCalledWith('No layer passed to MapUtil.getLegendGraphicUrl.');
 
       logSpy.mockReset();
       logSpy.mockRestore();
@@ -497,28 +508,46 @@ describe('MapUtil', () => {
 
     it('logs a warning if called with an unsupported layersource', () => {
       const logSpy = jest.spyOn(Logger, 'warn');
-      const legendUrl = MapUtil.getLegendGraphicUrl(layer2);
+      const legendUrl = MapUtil.getLegendGraphicUrl(layer3);
       expect(legendUrl).toBeUndefined();
       expect(logSpy).toHaveBeenCalledWith('Source of "Food insecurity" is currently not supported by MapUtil.getLegendGraphicUrl.');
       logSpy.mockReset();
       logSpy.mockRestore();
     });
 
-    it('returns a getLegendGraphicUrl from a given layer', () => {
-      const legendUrl = MapUtil.getLegendGraphicUrl(layer1);
-      const url = 'https://ows.terrestris.de/osm-gray/service?';
-      const layerParam = 'LAYER=OSM-WMS';
-      const versionParam = 'VERSION=1.3.0';
-      const serviceParam = 'SERVICE=WMS';
-      const requestParam = 'REQUEST=getLegendGraphic';
-      const formatParam = 'FORMAT=image%2Fpng';
+    describe('returns a getLegendGraphicUrl from a given layer', () => {
+      it('… for a tiled Layer', () => {
+        const legendUrl = MapUtil.getLegendGraphicUrl(layer1);
+        const url = 'https://ows.terrestris.de/osm-gray/service?';
+        const layerParam = 'LAYER=OSM-WMS';
+        const versionParam = 'VERSION=1.3.0';
+        const serviceParam = 'SERVICE=WMS';
+        const requestParam = 'REQUEST=getLegendGraphic';
+        const formatParam = 'FORMAT=image%2Fpng';
 
-      expect(legendUrl).toContain(url);
-      expect(legendUrl).toContain(layerParam);
-      expect(legendUrl).toContain(versionParam);
-      expect(legendUrl).toContain(serviceParam);
-      expect(legendUrl).toContain(requestParam);
-      expect(legendUrl).toContain(formatParam);
+        expect(legendUrl).toContain(url);
+        expect(legendUrl).toContain(layerParam);
+        expect(legendUrl).toContain(versionParam);
+        expect(legendUrl).toContain(serviceParam);
+        expect(legendUrl).toContain(requestParam);
+        expect(legendUrl).toContain(formatParam);
+      });
+      it('… for an image Layer', () => {
+        const legendUrl = MapUtil.getLegendGraphicUrl(layer2);
+        const url = 'https://ows.terrestris.de/osm-gray/service?';
+        const layerParam = 'LAYER=OSM-WMS';
+        const versionParam = 'VERSION=1.3.0';
+        const serviceParam = 'SERVICE=WMS';
+        const requestParam = 'REQUEST=getLegendGraphic';
+        const formatParam = 'FORMAT=image%2Fpng';
+
+        expect(legendUrl).toContain(url);
+        expect(legendUrl).toContain(layerParam);
+        expect(legendUrl).toContain(versionParam);
+        expect(legendUrl).toContain(serviceParam);
+        expect(legendUrl).toContain(requestParam);
+        expect(legendUrl).toContain(formatParam);
+      });
     });
 
     it('accepts extraParams for the request', () => {


### PR DESCRIPTION
This adds support for `OlSourceImageWMS` layers to the `getLegendGraphicUrl` method.