### PR TITLE
Add `getCombinedRequests` method to `WfsSearchUtil`

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,1 +1,4 @@
 import 'whatwg-fetch';
+import { XMLSerializer } from 'xmldom';
+
+global.XMLSerializer = XMLSerializer;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "node-pre-gyp": "0.11.0",
     "np": "3.0.4",
     "ol": "5.2.0",
-    "whatwg-fetch": "2.0.4"
+    "whatwg-fetch": "2.0.4",
+    "xmldom": "0.1.27"
   },
   "peerDependencies": {
     "ol": "~5.0"


### PR DESCRIPTION
Extract `getCombinedRequests` from `react-geo` package and place it inside of `WfsSearchUtil` to make shared usage more comfortable.

Related to  https://github.com/terrestris/react-geo/pull/878

Please review @terrestris/devs 