### PR TITLE
added `getZoomForScale` method to `MapUtil`

### DIFF
--- a/src/MapUtil/MapUtil.js
+++ b/src/MapUtil/MapUtil.js
@@ -10,6 +10,8 @@ import { Logger } from '@terrestris/base-util';
 
 import FeatureUtil from '../FeatureUtil/FeatureUtil';
 
+import findIndex from 'lodash/findIndex';
+
 /**
  * Helper Class for the ol3 map.
  *
@@ -392,6 +394,38 @@ export class MapUtil {
     return roundScale;
   }
 
+  /**
+   * Returns the appropriate zoom level for the given scale and units.
+
+   * @method
+   * @param {Number} scale Map scale to get the zoom for.
+   * @param {Array} resolutions Resolutions array.
+   * @param {String} units The units the resolutions are based on, typically
+   *                       either 'm' or 'degrees'. Default is 'm'.
+   *
+   * @return {Number} Determined zoom level for the given scale.
+   */
+  static getZoomForScale(scale, resolutions, units = 'm') {
+    if (Number.isNaN(Number(scale))) {
+      return 0;
+    }
+
+    if (scale < 0) {
+      return 0;
+    }
+
+    let calculatedResolution = MapUtil.getResolutionForScale(scale, units);
+    let closestVal = resolutions.reduce((prev, curr) => {
+      let res = Math.abs(curr - calculatedResolution) < Math.abs(prev - calculatedResolution)
+        ? curr
+        : prev;
+      return res;
+    });
+    let zoom = findIndex(resolutions, function(o) {
+      return Math.abs(o - closestVal) <= 1e-10;
+    });
+    return zoom;
+  }
 }
 
 export default MapUtil;

--- a/src/MapUtil/MapUtil.spec.js
+++ b/src/MapUtil/MapUtil.spec.js
@@ -767,4 +767,46 @@ describe('MapUtil', () => {
       expect(got).toBeUndefined();
     });
   });
+
+  describe('#getZoomForScale', () => {
+    it('is defined', () => {
+      expect(MapUtil.getZoomForScale).toBeDefined();
+    });
+
+    it('returns 0 if non numeric scale is provided', () => {
+      const got = MapUtil.getZoomForScale('scale', [1, 2]);
+      expect(got).toBe(0);
+    });
+
+    it('returns 0 if negative scale is provided', () => {
+      const got = MapUtil.getZoomForScale(-1, [1, 2]);
+      expect(got).toBe(0);
+    });
+
+    it('calls getResolutionForScale method', () => {
+      const spy = jest.spyOn(MapUtil, 'getResolutionForScale');
+      MapUtil.getZoomForScale(2000, [1, 2, 3]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it('returns zoom level for provided resolution', () => {
+      const mercatorResolutions = [
+        1.19432856696, // 4265
+        0.597164283478, // 2132
+        0.298582141739, // 1066
+        0.149291070869 // 533
+      ];
+      const testScales = [5000, 2500, 1000, 500];
+      let index = 0;
+
+      testScales.forEach(scale => {
+        expect(MapUtil.getZoomForScale(scale, mercatorResolutions)).toBe(index);
+        index++;
+      });
+    });
+  });
 });


### PR DESCRIPTION
SInce the method `getZoomForScale` is repeatedly used across different projects, add it to the util.

Please review @terrestris/devs 