### PR TITLE
Minor adjustments to documentation

### DIFF
--- a/src/AnimateUtil/AnimateUtil.js
+++ b/src/AnimateUtil/AnimateUtil.js
@@ -71,7 +71,7 @@ class AnimateUtil {
           unByKey(listenerKey);
           resolve(featureToMove);
         }
-        // tell OL3 to continue postcompose animation
+        // tell OpenLayers to continue postcompose animation
         frameState.animate = true;
 
         actualFrames++;

--- a/src/CapabilitiesUtil/CapabilitiesUtil.js
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.js
@@ -5,7 +5,7 @@ import OlLayerImage from 'ol/layer/Image';
 import get from 'lodash/get.js';
 
 /**
- * Helper Class to parse capabilities of WMS layers
+ * Helper class to parse capabilities of WMS layers
  *
  * @class CapabilitiesUtil
  */

--- a/src/FeatureUtil/FeatureUtil.js
+++ b/src/FeatureUtil/FeatureUtil.js
@@ -3,7 +3,7 @@ import isString from 'lodash/isString.js';
 import { StringUtil } from '@terrestris/base-util';
 
 /**
- * Helper Class for the ol features.
+ * Helper class for working with OpenLayers features.
  *
  * @class FeatureUtil
  */

--- a/src/FileUtil/FileUtil.js
+++ b/src/FileUtil/FileUtil.js
@@ -4,7 +4,7 @@ import OlSourceVector from 'ol/source/Vector';
 import shp from 'shpjs';
 
 /**
- * Helper Class for adding layers from various file formats.
+ * Helper class for adding layers from various file formats.
  *
  * @class
  */

--- a/src/GeometryUtil/GeometryUtil.js
+++ b/src/GeometryUtil/GeometryUtil.js
@@ -16,7 +16,8 @@ import lineToPolygon from '@turf/line-to-polygon';
 import { polygon as makePolygon } from '@turf/helpers';
 
 /**
- * Helper Class for the geospatial analysis.
+ * Helper class for the geospatial analysis. Makes use of
+ * [Turf.js](http://turfjs.org/).
  *
  * @class GeometryUtil
  */

--- a/src/MapUtil/MapUtil.js
+++ b/src/MapUtil/MapUtil.js
@@ -13,7 +13,7 @@ import FeatureUtil from '../FeatureUtil/FeatureUtil';
 import findIndex from 'lodash/findIndex';
 
 /**
- * Helper Class for the ol3 map.
+ * Helper class for the OpenLayers map.
  *
  * @class
  */

--- a/src/ProjectionUtil/ProjectionUtil.js
+++ b/src/ProjectionUtil/ProjectionUtil.js
@@ -23,7 +23,8 @@ export const defaultProj4CrsMappings = {
 };
 
 /**
- * Helper class for ol/proj4 projection handling.
+ * Helper class for projection handling. Makes use of
+ * [Proj4js](http://proj4js.org/).
  *
  * @class ProjectionUtil
  */

--- a/src/TestUtil.js
+++ b/src/TestUtil.js
@@ -55,7 +55,7 @@ export class TestUtil {
   };
 
   /**
-   * Creates an ol map.
+   * Creates an OpenLayers map.
    *
    * @param {Object} mapOpts Additional options for the map to create.
    * @return {ol.Map} The ol map.

--- a/src/WfsFilterUtil/WfsFilterUtil.js
+++ b/src/WfsFilterUtil/WfsFilterUtil.js
@@ -7,7 +7,7 @@ import {
 import OlFormatWFS from 'ol/format/WFS';
 
 /**
- * Helper Class for building filters to be used with WFS GetFeature requests.
+ * Helper class for building filters to be used with WFS GetFeature requests.
  *
  * @class WfsFilterUtil
  */


### PR DESCRIPTION
* No more `ol3`, just `OpenLayers`
* No more `ol`, just `OpenLayers`
* Fix spelling of `class` (lower case)
* Mention and link to [Proj4js](http://proj4js.org/) and [Turf.js](http://turfjs.org/) where appropriate

Please review.