### PR TITLE
Fix spelling of capabilities in public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm i @terrestris/ol-util
 -   [CapabilitiesUtil](#capabilitiesutil)
     -   [parseWmsCapabilities](#parsewmscapabilities)
         -   [Parameters](#parameters-1)
-    -   [getLayersFromWmsCapabilties](#getlayersfromwmscapabilties)
+    -   [getLayersFromWmsCapabilities](#getlayersfromwmscapabilities)
         -   [Parameters](#parameters-2)
 -   [FeatureUtil](#featureutil)
     -   [getFeatureTypeName](#getfeaturetypename)
@@ -150,7 +150,7 @@ Parses the given WMS Capabilities string.
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** An object representing the WMS capabilities.
 
-#### getLayersFromWmsCapabilties
+#### getLayersFromWmsCapabilities
 
 Returns the layers from a parsed WMS GetCapabilities object.
 
@@ -510,7 +510,7 @@ Currently supported Sources:
 ##### Parameters
 
 -   `layer` **ol.layer.Layer** The layer that you want to have a legendUrlfor.
--   `extraParams`  
+-   `extraParams`
 
 Returns **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined))** The getLegendGraphicUrl.
 

--- a/src/CapabilitiesUtil/CapabilitiesUtil.js
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.js
@@ -38,7 +38,7 @@ class CapabilitiesUtil {
    *                           requests to avoid CORS issues.
    * @return {OlLayerTile[]} Array of OlLayerTile
    */
-  static getLayersFromWmsCapabilties(capabilities, nameField = 'Name', proxyFn) {
+  static getLayersFromWmsCapabilities(capabilities, nameField = 'Name', proxyFn) {
     const wmsVersion = get(capabilities,'version');
     const wmsAttribution = get(capabilities,'Service.AccessConstraints');
     const layersInCapabilities = get(capabilities,'Capability.Layer.Layer');

--- a/src/CapabilitiesUtil/CapabilitiesUtil.spec.js
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.spec.js
@@ -147,13 +147,13 @@ describe('CapabilitiesUtil', () => {
       });
     });
 
-    describe('getLayersFromWmsCapabilties', () => {
+    describe('getLayersFromWmsCapabilities', () => {
       it('isDefined', () => {
-        expect(CapabilitiesUtil.getLayersFromWmsCapabilties).not.toBeUndefined();
+        expect(CapabilitiesUtil.getLayersFromWmsCapabilities).not.toBeUndefined();
       });
 
       it('creates layer objects from parsed WMS capabilities', () => {
-        const parsedLayers = CapabilitiesUtil.getLayersFromWmsCapabilties(capabilitiesObj);
+        const parsedLayers = CapabilitiesUtil.getLayersFromWmsCapabilities(capabilitiesObj);
         expect(parsedLayers).toHaveLength(1);
         const layer = parsedLayers[0];
         expect(layer).toBeInstanceOf(OlLayerImage);
@@ -161,7 +161,7 @@ describe('CapabilitiesUtil', () => {
       });
 
       it('sets layer attributes accordingly', () => {
-        const parsedLayers = CapabilitiesUtil.getLayersFromWmsCapabilties(capabilitiesObj);
+        const parsedLayers = CapabilitiesUtil.getLayersFromWmsCapabilities(capabilitiesObj);
         const layer = parsedLayers[0];
         const layerSource = layer.getSource();
         expect(layer.get('title')).toBe(layerTitle);
@@ -179,7 +179,7 @@ describe('CapabilitiesUtil', () => {
 
       it('applies proxy function if provided', () => {
         const proxyFn = jest.fn();
-        CapabilitiesUtil.getLayersFromWmsCapabilties(capabilitiesObj, 'name', proxyFn);
+        CapabilitiesUtil.getLayersFromWmsCapabilities(capabilitiesObj, 'name', proxyFn);
         expect.assertions(1);
         expect(proxyFn).toBeCalledTimes(3);
       });


### PR DESCRIPTION
This PR suggests to rename `getLayersFromWmsCapabilties` to `getLayersFromWmsCapabilities`, which is a [SemVer](https://semver.org/) MAJOR change.

Please review. 