### PR TITLE
Added getFeatureTypeNameFromGetFeatureInfoUrl method

### DIFF
--- a/src/FeatureUtil/FeatureUtil.js
+++ b/src/FeatureUtil/FeatureUtil.js
@@ -1,4 +1,5 @@
 import isString from 'lodash/isString.js';
+import isArray from 'lodash/isArray';
 
 import StringUtil from '@terrestris/base-util/dist/StringUtil/StringUtil';
 
@@ -22,7 +23,29 @@ class FeatureUtil {
     let featureId = feature.getId();
     let featureIdParts = featureId ? featureId.split('.') : featureId;
 
-    return Array.isArray(featureIdParts) ? featureIdParts[0] : undefined;
+    return isArray(featureIdParts) ? featureIdParts[0] : undefined;
+  }
+
+  /**
+   * Extracts the featureType name from given GetFeatureInfo URL.
+   * This method is mostly useful for raster layers which features could have
+   * no ID set.
+   *
+   * @param {string} url GetFeatureInfo URL possibly containing featureType name.
+   *
+   * @return {string} Obtained featureType name as string.
+   */
+  static getFeatureTypeNameFromGetFeatureInfoUrl(url) {
+    const regex = /query_layers=(.*?)&/i;
+    let match = url.match(regex);
+    let featureTypeName;
+    if (isArray(match) && match[1]) {
+      featureTypeName = decodeURIComponent(match[1]);
+      if (featureTypeName.indexOf(':') > 0) {
+        featureTypeName = featureTypeName.split(':')[1];
+      }
+    }
+    return featureTypeName;
   }
 
   /**

--- a/src/FeatureUtil/FeatureUtil.spec.js
+++ b/src/FeatureUtil/FeatureUtil.spec.js
@@ -60,6 +60,30 @@ describe('FeatureUtil', () => {
       });
     });
 
+    describe('#getFeatureTypeNameFromGetFeatureInfoUrl', () => {
+
+      it('extacts layer name from provided GetFeatureInfo request URL', () => {
+
+        const layerName = 'testLayerName';
+        const mockUrlUnqualified = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=${layerName}&TILED=true`;
+        const mockUrlQualified = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=Namespace:${layerName}&TILED=true`;
+
+        const got = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlUnqualified);
+        const got2 = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified);
+
+        expect(got).toBe(layerName);
+        expect(got2).toBe(layerName);
+      });
+
+      it('returns undefined if no match was found', () => {
+
+        const notMatchingUrl = `http://mock.de?&REQUEST=GetFeatureInfo&SOME_PARAMS=some_values`;
+        const got = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(notMatchingUrl);
+        expect(got).toBeUndefined();
+      });
+    });
+
+
     describe('#resolveAttributeTemplate', () => {
       it('resolves the given template string with the feature attributes', () => {
         let template = '{{name}}';


### PR DESCRIPTION
... which can be use to obtain feature type name from GetFeatureInfo request url like 
`http://localhost/geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&QUERY_LAYERS=ns:featureTypeName`

Please review @terrestris/devs 