### PR TITLE
Enhance behaviour of getFeatureTypeNameFromGetFeatureInfoUrl method

### DIFF
--- a/src/FeatureUtil/FeatureUtil.js
+++ b/src/FeatureUtil/FeatureUtil.js
@@ -32,16 +32,18 @@ class FeatureUtil {
    * no ID set.
    *
    * @param {string} url GetFeatureInfo URL possibly containing featureType name.
+   * @param {boolean} qualified Whether the qualified featureType name should be
+   *   returned or not. Default is true.
    *
    * @return {string} Obtained featureType name as string.
    */
-  static getFeatureTypeNameFromGetFeatureInfoUrl(url) {
-    const regex = /query_layers=(.*?)&/i;
+  static getFeatureTypeNameFromGetFeatureInfoUrl(url, qualified = true) {
+    const regex = /query_layers=(.*?)(&|$)/i;
     let match = url.match(regex);
     let featureTypeName;
-    if (isArray(match) && match[1]) {
+    if (match && match[1]) {
       featureTypeName = decodeURIComponent(match[1]);
-      if (featureTypeName.indexOf(':') > 0) {
+      if (!qualified && featureTypeName.indexOf(':') > 0) {
         featureTypeName = featureTypeName.split(':')[1];
       }
     }

--- a/src/FeatureUtil/FeatureUtil.spec.js
+++ b/src/FeatureUtil/FeatureUtil.spec.js
@@ -62,17 +62,25 @@ describe('FeatureUtil', () => {
 
     describe('#getFeatureTypeNameFromGetFeatureInfoUrl', () => {
 
-      it('extacts layer name from provided GetFeatureInfo request URL', () => {
+      it('extracts layer name from provided GetFeatureInfo request URL', () => {
 
         const layerName = 'testLayerName';
+        const ns = 'ns';
         const mockUrlUnqualified = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=${layerName}&TILED=true`;
-        const mockUrlQualified = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=Namespace:${layerName}&TILED=true`;
+        const mockUrlQualified = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=${ns}:${layerName}&TILED=true`;
+        const mockUrlQualified2 = `http://mock.de?&REQUEST=GetFeatureInfo&QUERY_LAYERS=${ns}:${layerName}`;
 
-        const got = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlUnqualified);
-        const got2 = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified);
+        const gotUnqualified = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlUnqualified);
+        const gotQualified = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified);
+        const gotQualified2 = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified2);
+        const gotQualifiedSplitted = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified, false);
+        const gotQualifiedSplitted2 = FeatureUtil.getFeatureTypeNameFromGetFeatureInfoUrl(mockUrlQualified2, false);
 
-        expect(got).toBe(layerName);
-        expect(got2).toBe(layerName);
+        expect(gotUnqualified).toBe(layerName);
+        expect(gotQualified).toBe(`${ns}:${layerName}`);
+        expect(gotQualified2).toBe(`${ns}:${layerName}`);
+        expect(gotQualifiedSplitted).toBe(layerName);
+        expect(gotQualifiedSplitted2).toBe(layerName);
       });
 
       it('returns undefined if no match was found', () => {


### PR DESCRIPTION
Followup of #110, addresses issues mentioned by @marcjansen:
- Fixes feature type name determination if `query_layers` parameter is the last one in the URL
- Adds some further tests
- Adds an additional config to choose i thef featureType name should be returned qualified (e.g. `namespace:featureTypeName`) or not.

Please take a look @marcjansen, TIA.