### PR TITLE
Run with node version 10, 12 and 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- "8"
 - "10"
+- "12"
+- "14"
 script:
 - npm run test -- --coverage
 after_success:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "dist",
     "babel.config.js"
   ],
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "scripts": {
     "clean:dist": "rimraf ./dist/*",
     "clean:docs": "rimraf build/docs",


### PR DESCRIPTION
This also removes version 8 because documentation (and several other dev dependencies) dropped support for it.

Please review @terrestris/devs.