### PR TITLE
Update OpenLayers, remove usage of MapBrowserPointerEvent in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4271,6 +4271,48 @@
         }
       }
     },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
+      "dev": true
+    },
+    "@mapbox/mapbox-gl-style-spec": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.17.0.tgz",
+      "integrity": "sha512-ZxOdHiuUmDcvQNc1uTnBLVJZxiQVYvoNZaQVxWwl+6Id6tjGQFtieZxXiv/RXIOpQQT35JuioatTKdsjpMsULA==",
+      "dev": true,
+      "requires": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.5",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "dev": true
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -7698,6 +7740,12 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
+      "dev": true
+    },
     "cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
@@ -8311,12 +8359,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-      "dev": true
-    },
-    "elm-pep": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/elm-pep/-/elm-pep-1.0.6.tgz",
-      "integrity": "sha512-1DJ6ReFk8+GtgoqRiEhBo28K69Rxe9Bfc7h16+1VMQT2KlCuPBYj5W33OYa2AZpqkuqCBLhcNzO10zxJVakapA==",
       "dev": true
     },
     "email-addresses": {
@@ -12387,6 +12429,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -12940,6 +12988,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "mapbox-to-css-font": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
+      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
+      "dev": true
     },
     "markdown-escapes": {
       "version": "1.0.4",
@@ -14127,14 +14181,13 @@
       }
     },
     "ol": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.3.1.tgz",
-      "integrity": "sha512-cSSYizzUJQ7AhFSrLPAKopjDXPCHtJsXSmjf3xutPG+iyBeD9IOepQGSgpOSZavPI1gsYh9wowiH+NZwVJ/NYQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.4.3.tgz",
+      "integrity": "sha512-JcoZ/VJE9cUoxfhpa2EFYH0AHFYty1x47aITsQgLkyvWIWWigWp1N9LBcCSlCuu2QkE+DutomI2oKfnFbQA/xw==",
       "dev": true,
       "requires": {
-        "elm-pep": "^1.0.4",
+        "ol-mapbox-style": "^6.1.1",
         "pbf": "3.2.1",
-        "pixelworks": "1.1.0",
         "rbush": "^3.0.1"
       },
       "dependencies": {
@@ -14153,6 +14206,17 @@
             "quickselect": "^2.0.0"
           }
         }
+      }
+    },
+    "ol-mapbox-style": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.1.4.tgz",
+      "integrity": "sha512-XyOk6oGTGtFnj6gRvMwdKZft9s1QeSh9toQRGT7vFr8fS9yV8fSVJnrdmicGTYDYkUVmL+B3Sebi2jc1oEdouQ==",
+      "dev": true,
+      "requires": {
+        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
+        "mapbox-to-css-font": "^2.4.0",
+        "webfont-matcher": "^1.1.0"
       }
     },
     "once": {
@@ -14697,12 +14761,6 @@
       "requires": {
         "node-modules-regexp": "^1.0.0"
       }
-    },
-    "pixelworks": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pixelworks/-/pixelworks-1.1.0.tgz",
-      "integrity": "sha1-Hwla1I3Ki/ihyCWOAJIDGkTyLKU=",
-      "dev": true
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -15553,6 +15611,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
@@ -15921,6 +15985,18 @@
         }
       }
     },
+    "sort-asc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
+      "dev": true
+    },
+    "sort-desc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
+      "dev": true
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -15928,6 +16004,16 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-object": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "dev": true,
+      "requires": {
+        "sort-asc": "^0.1.0",
+        "sort-desc": "^0.1.1"
       }
     },
     "source-map": {
@@ -17440,6 +17526,12 @@
       "requires": {
         "makeerror": "1.0.x"
       }
+    },
+    "webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jest-canvas-mock": "^2.2.0",
     "node-pre-gyp": "^0.15.0",
     "np": "^6.2.0",
-    "ol": "^6.1.1",
+    "ol": "^6.4.3",
     "rimraf": "^3.0.0",
     "shp-write": "^0.3.2",
     "whatwg-fetch": "^3.0.0",

--- a/src/TestUtil.js
+++ b/src/TestUtil.js
@@ -4,7 +4,7 @@ import OlSourceVector from 'ol/source/Vector';
 import OlLayerVector from 'ol/layer/Vector';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
-import OlMapBrowserPointerEvent from 'ol/MapBrowserPointerEvent';
+import OlMapBrowserEvent from 'ol/MapBrowserPointerEvent';
 
 /**
  * A set of some useful static helper methods.
@@ -113,7 +113,7 @@ export class TestUtil {
     event.clientX = position.left + x + TestUtil.mapDivWidth / 2;
     event.clientY = position.top + y + TestUtil.mapDivHeight / 2;
     event.shiftKey = shiftKey;
-    map.handleMapBrowserEvent(new OlMapBrowserPointerEvent(type, map, event, dragging));
+    map.handleMapBrowserEvent(new OlMapBrowserEvent(type, map, event, dragging));
   }
 
   /**

--- a/src/TestUtil.js
+++ b/src/TestUtil.js
@@ -4,7 +4,7 @@ import OlSourceVector from 'ol/source/Vector';
 import OlLayerVector from 'ol/layer/Vector';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
-import OlMapBrowserEvent from 'ol/MapBrowserPointerEvent';
+import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 
 /**
  * A set of some useful static helper methods.


### PR DESCRIPTION
In OpenLayers, the `MapBrowserPointerEvent` export / class was removed  in https://github.com/openlayers/openlayers/pull/11025 (more specifically [this commit](https://github.com/openlayers/openlayers/pull/11025/commits/33ce206babec37ce035ffab3553817b0fdee2ca5), released with `ol@6.4.3`). This broke our tests when we wanted to upgrade OpenLayers.

Dependabot opened #272 (`Cannot find module 'ol/MapBrowserPointerEvent' from 'TestUtil.js'` see [failing Travis logs](https://travis-ci.com/github/terrestris/ol-util/jobs/399585765)), in there only the lockfile is updated, while this also updates `package.json`. I do not know whether this might be problematic. Since we always specified a `peerDependency` on ol@6, I doubt that it though.

Please review.

Closes #272 