### PR TITLE
Update CapabilitiesUtil and init LayerUtil

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
   'plugins': [
     '@babel/plugin-proposal-function-bind',
     '@babel/plugin-transform-modules-commonjs',
+    '@babel/plugin-transform-runtime',
     ['@babel/plugin-proposal-class-properties', { 'loose': false }],
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3262,6 +3262,34 @@
         }
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.10.tgz",
+      "integrity": "sha512-Y5k8ipgfvz5d/76tx7JYbKQTcgFSU6VgJ3kKQv4zGTKr+a9T/KBvfRvGtSFgKDQGt/DBykQixV0vNWKIdzWErA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "babel-plugin-polyfill-corejs2": "^0.1.4",
+        "babel-plugin-polyfill-corejs3": "^0.1.3",
+        "babel-plugin-polyfill-regenerator": "^0.1.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",
+    "@babel/plugin-transform-runtime": "^7.13.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
+    "@babel/runtime": "^7.13.10",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "canvas": "^2.6.1",

--- a/src/FileUtil/FileUtil.spec.js
+++ b/src/FileUtil/FileUtil.spec.js
@@ -24,7 +24,6 @@ const geoJson2 = {
   }]
 };
 
-
 describe('FileUtil', () => {
   const geoJsonFile = new File([JSON.stringify(geoJson)], 'geo.json', {
     type: 'application/json',

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -1,0 +1,78 @@
+import OlSourceImageWMS from 'ol/source/ImageWMS';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlSourceWMTS from 'ol/source/WMTS';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+
+import CapabilitiesUtil from '../CapabilitiesUtil/CapabilitiesUtil';
+
+/**
+ * Helper class for layer interaction.
+ *
+ * @class LayerUtil
+ */
+class LayerUtil {
+
+  /**
+   * Returns the configured URL of the given layer.
+   *
+   * @param {ol.layer.Layer} layer The layer to get the URL from.
+   * @returns The layer URL.
+   */
+  static getLayerUrl = layer => {
+    const layerSource = layer.getSource();
+    let layerUrl;
+
+    if (layerSource instanceof OlSourceTileWMS) {
+      layerUrl = layerSource.getUrls()[0];
+    } else if (layerSource instanceof OlSourceImageWMS) {
+      layerUrl = layerSource.getUrl();
+    } else if (layerSource instanceof OlSourceWMTS) {
+      layerUrl = layerSource.getUrls()[0];
+    } else {
+      Logger.error('The given source type is not supported.');
+    }
+
+    return layerUrl;
+  }
+
+  /**
+   * Returns the extent of the given layer as defined in the
+   * appropriate Capabilities document.
+   *
+   * @param {ol.layer.Layer} layer
+   * @returns The extent of the layer.
+   */
+  static async getExtentForLayer(layer) {
+    const capabilities = await CapabilitiesUtil.getWmsCapabilitiesByLayer(layer);
+
+    if (!capabilities || !capabilities.Capability || !capabilities.Capability.Layer ||
+      !capabilities.Capability.Layer.Layer) {
+      Logger.error('Unexpected format of the Capabilities.');
+      return;
+    }
+
+    const layerName = layer.getSource().getParams().LAYERS;
+
+    const layers = capabilities.Capability.Layer.Layer.filter((l) => {
+      return l.Name === layerName;
+    });
+
+    if (!layers || layers.length === 0) {
+      Logger.error('Could not find the desired layer in the Capabilities.');
+      return;
+    }
+
+    const extent = layers[0].EX_GeographicBoundingBox;
+
+    if (!extent || extent.length !== 4) {
+      Logger.error('No extent set in the Capabilities.');
+      return;
+    }
+
+    return extent;
+  }
+
+}
+
+export default LayerUtil;

--- a/src/LayerUtil/LayerUtil.spec.js
+++ b/src/LayerUtil/LayerUtil.spec.js
@@ -1,0 +1,108 @@
+/*eslint-env jest*/
+
+import OlLayerTile from 'ol/layer/Tile';
+import OlLayerImage from 'ol/layer/Image';
+import OlLayerVector from 'ol/layer/Vector';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlSourceImageWMS from 'ol/source/ImageWMS';
+import OlSourceVector from 'ol/source/Vector';
+import OlSourceWMTS from 'ol/source/WMTS';
+
+import LayerUtil from './LayerUtil';
+import CapabilitiesUtil from '../CapabilitiesUtil/CapabilitiesUtil';
+
+describe('LayerUtil', () => {
+  it('is defined', () => {
+    expect(LayerUtil).not.toBeUndefined();
+  });
+
+  describe('Static methods', () => {
+    describe('#getLayerUrl', () => {
+      it('returns the url of a supported layer/source type', () => {
+        const layer1 = new OlLayerTile({
+          name: 'OSM-WMS',
+          source: new OlSourceTileWMS({
+            url: 'https://ows.terrestris.de/osm-gray/service?',
+            params: {
+              LAYERS: 'OSM-WMS'
+            }
+          })
+        });
+
+        const url1 = LayerUtil.getLayerUrl(layer1);
+
+        expect(url1).toEqual('https://ows.terrestris.de/osm-gray/service?');
+
+        const layer2 = new OlLayerImage({
+          name: 'OSM-WMS',
+          source: new OlSourceImageWMS({
+            url: 'https://ows.terrestris.de/osm-gray/service',
+            params: {
+              'LAYERS': 'OSM-WMS'
+            }
+          })
+        });
+
+        const url2 = LayerUtil.getLayerUrl(layer2);
+
+        expect(url2).toEqual('https://ows.terrestris.de/osm-gray/service');
+
+        const layer3 = new OlLayerTile({
+          name: 'OSM-WMS',
+          source: new OlSourceWMTS({
+            url: 'https://ows.terrestris.de/osm-gray/service'
+          })
+        });
+
+        const url3 = LayerUtil.getLayerUrl(layer3);
+
+        expect(url3).toEqual('https://ows.terrestris.de/osm-gray/service');
+      });
+
+      it('returns undefined for an unsupported layer/source type', () => {
+        const layer = new OlLayerVector({
+          source: new OlSourceVector()
+        });
+
+        const url = LayerUtil.getLayerUrl(layer);
+
+        expect(url).toBeUndefined();
+      });
+    });
+
+    describe('#getExtentForLayer', () => {
+      it('returns the extent of the given layer', async () => {
+        const layer = new OlLayerTile({
+          name: 'OSM-WMS',
+          source: new OlSourceTileWMS({
+            url: 'https://ows.terrestris.de/osm-gray/service?',
+            params: {
+              LAYERS: 'OSM-WMS'
+            }
+          })
+        });
+
+        const mockImpl = jest.fn();
+        mockImpl.mockReturnValue({
+          Capability: {
+            Layer: {
+              Layer: [{
+                Name: 'OSM-WMS',
+                EX_GeographicBoundingBox: [1, 2, 3, 4]
+              }]
+            }
+          }
+        });
+        const getWmsCapabilitiesByLayerSpy = jest.spyOn(CapabilitiesUtil,
+          'getWmsCapabilitiesByLayer').mockImplementation(mockImpl);
+
+        const extent = await LayerUtil.getExtentForLayer(layer);
+
+        expect(extent).toEqual([1, 2, 3, 4]);
+
+        getWmsCapabilitiesByLayerSpy.mockRestore();
+      });
+    });
+
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import CapabilitiesUtil from './CapabilitiesUtil/CapabilitiesUtil';
 import FeatureUtil from './FeatureUtil/FeatureUtil';
 import FileUtil from './FileUtil/FileUtil';
 import GeometryUtil from './GeometryUtil/GeometryUtil';
+import LayerUtil from './LayerUtil/LayerUtil';
 import MapUtil from './MapUtil/MapUtil';
 import MeasureUtil from './MeasureUtil/MeasureUtil';
 import PermalinkUtil from './PermalinkUtil/PermalinkUtil';
@@ -15,6 +16,7 @@ export {
   FeatureUtil,
   FileUtil,
   GeometryUtil,
+  LayerUtil,
   MapUtil,
   MeasureUtil,
   PermalinkUtil,


### PR DESCRIPTION
This updates the `CapabilitiesUtil` by adding the methods `getWmsCapabilities()`, `getWmsCapabilitiesByLayer()` and `getCapabilitiesUrl()` and initializes the `LayerUtil` including `getExtentForLayer()`.

The existing method `parseWmsCapabilities()` has been deprecated in favour of `getWmsCapabilities()` (thus no breaking change.)

Tests were failing locally with `ReferenceError: regeneratorRuntime is not defined`, this has been fixed by adding `@babel/plugin-transform-runtime` and `@babel/runtime`

Please review @terrestris/devs.