### PR TITLE
Make layer filter and identifier configurable

### DIFF
--- a/src/PermalinkUtil/PermalinkUtil.spec.js
+++ b/src/PermalinkUtil/PermalinkUtil.spec.js
@@ -233,16 +233,5 @@ describe('PermalinkUtil', () => {
       });
     });
 
-    describe('#getSeparator', () => {
-      it('returns separator value if provied as argument', () => {
-        const separator = '---';
-        const got = PermalinkUtil.getSeparator(separator);
-        expect(got).toBe(separator);
-      });
-      it('returns semicolon if called with undefined argument', () => {
-        const got = PermalinkUtil.getSeparator();
-        expect(got).toBe(';');
-      });
-    });
   });
 });


### PR DESCRIPTION
This updates the `getLink` and `applyLink` methods in the `PermalinkUtil` to accept a custom layer filter and identifier.

Please review @terrestris/devs.