### PR TITLE
Remove dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ol-util
 
-[![Dependabot badge](https://api.dependabot.com/badges/status?host=github&repo=terrestris/ol-util)](https://dependabot.com/)
 [![Build Status](https://travis-ci.org/terrestris/ol-util.svg?branch=master)](https://travis-ci.org/terrestris/ol-util)
 [![Coverage Status](https://coveralls.io/repos/github/terrestris/ol-util/badge.svg?branch=master)](https://coveralls.io/github/terrestris/ol-util?branch=master)
 


### PR DESCRIPTION
The badge is showing a 'wrong' message anyhow.

![Unbenannt](https://user-images.githubusercontent.com/227934/138702940-67bb9fb4-2b2a-4fb7-a139-c4496f2c5352.png)

Please review.