### PR TITLE
chore: enable typescript to emit declarations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,14 @@
 module.exports = {
   'presets': [
     '@babel/env',
-    '@babel/react'
+    '@babel/react',
+    '@babel/preset-typescript'
   ],
   'plugins': [
     '@babel/plugin-proposal-function-bind',
     '@babel/plugin-transform-modules-commonjs',
     '@babel/plugin-transform-runtime',
+    '@babel/plugin-transform-typescript',
     ['@babel/plugin-proposal-class-properties', { 'loose': false }],
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.7",
         "proj4": "^2.7.5",
-        "shpjs": "^4.0.2"
+        "shpjs": "^4.0.2",
+        "typescript": "^4.5.5"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.3",
@@ -25,6 +26,7 @@
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
         "@babel/runtime": "^7.17.2",
         "babel-jest": "^27.5.1",
         "canvas": "^2.9.0",
@@ -1641,6 +1643,23 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
+      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-typescript": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
@@ -1788,6 +1807,23 @@
         "@babel/plugin-transform-react-jsx": "^7.16.7",
         "@babel/plugin-transform-react-jsx-development": "^7.16.7",
         "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
+      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "@babel/plugin-transform-typescript": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -19659,6 +19695,18 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
@@ -21874,6 +21922,17 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
+      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-typescript": "^7.16.7"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
@@ -22000,6 +22059,17 @@
         "@babel/plugin-transform-react-jsx": "^7.16.7",
         "@babel/plugin-transform-react-jsx-development": "^7.16.7",
         "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
+      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "@babel/plugin-transform-typescript": "^7.16.7"
       }
     },
     "@babel/runtime": {
@@ -35901,6 +35971,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "uglify-js": {
       "version": "3.15.1",

--- a/package.json
+++ b/package.json
@@ -15,22 +15,24 @@
     "npm": ">=7"
   },
   "scripts": {
+    "build": "npm run test && npm run build:dist && npm run build:declarations",
+    "build:declarations": "tsc --emitDeclarationOnly",
+    "build:docs": "npm run clean:docs && documentation build -g -f html -o build/docs src/index.js",
+    "build:dist": "npm run clean:dist && BABEL_ENV=production babel src --out-dir dist --copy-files --ignore **/*.spec.js --extensions \".ts,.js\"",
     "clean:dist": "rimraf ./dist/*",
     "clean:docs": "rimraf build/docs",
+    "coveralls": "cat coverage/lcov.info | coveralls",
+    "deploy": "NODE_DEBUG=gh-pages node tasks/update-gh-pages.js",
     "lint:src": "eslint --ext js src/",
     "lint:docs": "documentation lint src/index.js",
     "lint": "npm run lint:src && npm run lint:docs",
-    "pretest": "npm run lint",
+    "prepublishOnly": "npm run build:dist",
+    "pretest": "npm run typecheck && npm run lint",
+    "release": "np --no-yarn && git push https://github.com/terrestris/ol-util.git master --tags && npm run build:docs && npm run deploy",
+    "start:docs": "documentation serve -w -g src/index.js",
     "test": "jest --maxWorkers=4 --coverage",
     "test:watch": "jest --watchAll",
-    "start:docs": "documentation serve -w -g src/index.js",
-    "build:docs": "npm run clean:docs && documentation build -g -f html -o build/docs src/index.js",
-    "build:dist": "npm run clean:dist && BABEL_ENV=production babel src --out-dir dist --copy-files --ignore **/*.spec.js",
-    "build": "npm run test && npm run build:dist",
-    "coveralls": "cat coverage/lcov.info | coveralls",
-    "prepublishOnly": "npm run build:dist",
-    "deploy": "NODE_DEBUG=gh-pages node tasks/update-gh-pages.js",
-    "release": "np --no-yarn && git push https://github.com/terrestris/ol-util.git master --tags && npm run build:docs && npm run deploy"
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -54,7 +56,8 @@
     "lodash": "^4.17.21",
     "polygon-splitter": "^0.0.7",
     "proj4": "^2.7.5",
-    "shpjs": "^4.0.2"
+    "shpjs": "^4.0.2",
+    "typescript": "^4.5.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.3",
@@ -65,6 +68,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
+    "@babel/preset-typescript": "^7.16.7",
     "@babel/runtime": "^7.17.2",
     "babel-jest": "^27.5.1",
     "canvas": "^2.9.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "rootDir": "./src/",
     "skipLibCheck": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["**/*.spec.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "es5",
+    "declaration": true,
+    "outDir": "dist/",
+    "rootDir": "./src/",
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
This PR enables typescript to emit declarations. It adds the needed babel plugins and configs to transpile typescript code.