### PR TITLE
fix: split geometry functions into 2 seperate functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
         "@babel/runtime": "^7.17.2",
+        "@types/shpjs": "^3.4.1",
         "babel-jest": "^27.5.1",
         "canvas": "^2.9.0",
         "coveralls": "^3.1.1",
@@ -4666,6 +4667,16 @@
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "dev": true,
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/shpjs": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/shpjs/-/shpjs-3.4.1.tgz",
+      "integrity": "sha512-xdJ65Zp2wslzyKKAid+PPl7Hxz5+eFS7W5G42RfryoJRk2u0CA+5jtX3wBgZhmz1s/mGX0PWzmKCBYTYgRsELg==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*",
         "@types/node": "*"
       }
     },
@@ -19039,6 +19050,16 @@
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/shpjs": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/shpjs/-/shpjs-3.4.1.tgz",
+      "integrity": "sha512-xdJ65Zp2wslzyKKAid+PPl7Hxz5+eFS7W5G42RfryoJRk2u0CA+5jtX3wBgZhmz1s/mGX0PWzmKCBYTYgRsELg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*",
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@babel/runtime": "^7.17.2",
+    "@types/shpjs": "^3.4.1",
     "babel-jest": "^27.5.1",
     "canvas": "^2.9.0",
     "coveralls": "^3.1.1",

--- a/src/FileUtil/FileUtil.js
+++ b/src/FileUtil/FileUtil.js
@@ -33,7 +33,7 @@ export class FileUtil {
     const reader = new FileReader();
     reader.readAsArrayBuffer(file);
     reader.addEventListener('loadend', () => {
-      const blob = reader.result;
+      const blob = /** @type {ArrayBuffer} */(reader.result);
       shp(blob).then(json => {
         FileUtil.addGeojsonLayer(json, map);
       });
@@ -42,7 +42,7 @@ export class FileUtil {
 
   /**
    * Adds a new vector layer from a geojson string.
-   * @param {string} json the geojson string
+   * @param {string|object} json the geojson string or object
    * @param {import("ol/Map").default} map the map to add the layer to
    */
   static addGeojsonLayer(json, map) {

--- a/src/GeometryUtil/GeometryUtil.js
+++ b/src/GeometryUtil/GeometryUtil.js
@@ -9,12 +9,34 @@ import difference from '@turf/difference';
 import intersect from '@turf/intersect';
 import union from '@turf/union';
 import polygonSplitter from 'polygon-splitter';
-import { flattenReduce } from '@turf/turf';
+import { flatten } from '@turf/turf';
+
+/** @typedef {import("ol/geom/Geometry").default} OlGeomGeometry */
+/** @typedef {import("ol/geom/Polygon").default} OlGeomPolygon */
+/** @typedef {import("ol/geom/Point").default} OlGeomPoint */
+/** @typedef {import("ol/geom/LineString").default} OlGeomLineString */
+/** @typedef {import("ol/geom/SimpleGeometry").default} OlGeomSimple */
 
 /**
  * @typedef {import("@turf/helpers").Feature<import("@turf/helpers").Polygon|import("@turf/helpers").MultiPolygon>} TurfFeature
  * See https://github.com/Turfjs/turf/issues/1658
  */
+
+/**
+ * @template {OlGeomGeometry} T
+ * @param {OlFeature<T>|T} featureOrGeom
+ */
+function toGeom(featureOrGeom) {
+  if (featureOrGeom instanceof OlFeature) {
+    const geom = featureOrGeom.getGeometry();
+    if (geom === undefined) {
+      throw new Error('Feature has no geometry.');
+    }
+    return geom;
+  } else {
+    return featureOrGeom;
+  }
+}
 
 /**
  * Helper class for the geospatial analysis. Makes use of
@@ -37,40 +59,54 @@ class GeometryUtil {
    * array with ol.Feature. If the target polygon (first param) is of type
    * ol.geom.Geometry it will return an array with ol.geom.Geometry.
    *
-   * @param {import("ol/Feature").default | import("ol/geom/Polygon").default} polygon The polygon geometry to split.
-   * @param {import("ol/Feature").default | import("ol/geom/LineString").default} line The line geometry to split the polygon
+   * @param {OlFeature<OlGeomPolygon> | OlGeomPolygon} polygon The polygon geometry to split.
+   * @param {OlFeature<OlGeomLineString> | OlGeomLineString} line The line geometry to split the polygon
    *  geometry with.
    * @param {import("ol/proj").ProjectionLike} projection The EPSG code of the input features.
    *  Default is to EPSG:3857.
-   * @returns {import("ol/Feature").default[] | import("ol/geom/Polygon").default[]} An array of instances of ol.feature
+   * @returns {OlFeature[] | OlGeomPolygon[]} An array of instances of ol.feature
    *  with/or ol.geom.Polygon
    */
   static splitByLine(polygon, line, projection = 'EPSG:3857') {
+    const returnFeature = polygon instanceof OlFeature;
+
+    const geometries = GeometryUtil.splitGeometryByLine(toGeom(polygon), toGeom(line), projection);
+
+    if (returnFeature) {
+      return geometries.map(geom => new OlFeature(geom));
+    } else {
+      return geometries;
+    }
+  }
+
+  /**
+   * Splits an ol.geom.Polygon by an ol.geom.LineString
+   * into an array of instances of ol.geom.Polygon.
+   *
+   * @param {OlGeomPolygon} polygon The polygon geometry to split.
+   * @param {OlGeomLineString} line The line geometry to split the polygon
+   *  geometry with.
+   * @param {import("ol/proj").ProjectionLike} projection The EPSG code of the input features.
+   *  Default is to EPSG:3857.
+   * @returns {OlGeomPolygon[]} An array of instances of ol.geom.Polygon
+   */
+  static splitGeometryByLine(polygon, line, projection = 'EPSG:3857') {
     const geoJsonFormat = new OlFormatGeoJSON({
       dataProjection: 'EPSG:4326',
       featureProjection: projection
     });
-    const polygonFeat = polygon instanceof OlFeature ? polygon
-      : new OlFeature({
-        geometry: polygon
-      });
-    const lineFeat = line instanceof OlFeature ? line
-      : new OlFeature({
-        geometry: line
-      });
-    const polyJson = geoJsonFormat.writeGeometryObject(polygonFeat.getGeometry());
-    const lineJson = geoJsonFormat.writeGeometryObject(lineFeat.getGeometry());
+
+    const polyJson = geoJsonFormat.writeGeometryObject(polygon);
+    const lineJson = geoJsonFormat.writeGeometryObject(line);
+
+    /** @type {import("@turf/helpers").AllGeoJSON} */
     const result = polygonSplitter(polyJson, lineJson);
-    const list = [];
-    flattenReduce(result, (acc, feature) => {
-      if (polygon instanceof OlFeature) {
-        acc.push(geoJsonFormat.readFeature(feature));
-      } else {
-        acc.push(geoJsonFormat.readGeometry(feature.geometry));
-      }
-      return list;
-    }, list);
-    return list;
+
+    const flattened = flatten(result);
+
+    return flattened.features.map(geojsonFeature => {
+      return /** @type {OlGeomPolygon} */ (geoJsonFormat.readGeometry(geojsonFeature.geometry));
+    });
   }
 
   /**
@@ -79,14 +115,32 @@ class GeometryUtil {
    * If the target is of type ol.Feature it will return an ol.Feature.
    * If the target is of type ol.geom.Geometry it will return ol.geom.Geometry.
    *
-   * @param {import("ol/geom/Geometry").default | import("ol/Feature").default} geometry The geometry.
+   * @param {OlGeomGeometry | OlFeature} geometryOrFeature The geometry.
    * @param {number} radius The buffer to add in meters.
    * @param {string} projection The projection of the input geometry as EPSG code.
    *  Default is to EPSG:3857.
    *
-   * @returns {import("ol/geom/Geometry").default | import("ol/Feature").default} The geometry or feature with the added buffer.
+   * @returns {OlGeomGeometry | OlFeature} The geometry or feature with the added buffer.
    */
-  static addBuffer(geometry, radius = 0, projection = 'EPSG:3857') {
+  static addBuffer(geometryOrFeature, radius = 0, projection = 'EPSG:3857') {
+    if (geometryOrFeature instanceof OlFeature) {
+      return new OlFeature(GeometryUtil.addGeometryBuffer(toGeom(geometryOrFeature), radius, projection));
+    } else {
+      return GeometryUtil.addGeometryBuffer(geometryOrFeature, radius, projection);
+    }
+  }
+
+  /**
+   * Adds a buffer to a given geometry.
+   *
+   * @param {OlGeomGeometry} geometry The geometry.
+   * @param {number} radius The buffer to add in meters.
+   * @param {string} projection The projection of the input geometry as EPSG code.
+   *  Default is to EPSG:3857.
+   *
+   * @returns {OlGeomGeometry} The geometry with the added buffer.
+   */
+  static addGeometryBuffer(geometry, radius = 0, projection = 'EPSG:3857') {
     if (radius === 0) {
       return geometry;
     }
@@ -94,24 +148,18 @@ class GeometryUtil {
       dataProjection: 'EPSG:4326',
       featureProjection: projection
     });
-    const geoJson = geometry instanceof OlFeature
-      ? geoJsonFormat.writeFeatureObject(geometry)
-      : geoJsonFormat.writeGeometryObject(geometry);
+    const geoJson = geoJsonFormat.writeGeometryObject(geometry);
     const buffered = buffer(geoJson, radius, {
       units: 'meters'
     });
-    if (geometry instanceof OlFeature) {
-      return geoJsonFormat.readFeature(buffered);
-    } else {
-      return geoJsonFormat.readGeometry(buffered.geometry);
-    }
+    return geoJsonFormat.readGeometry(buffered.geometry);
   }
 
   /**
    * Merges multiple geometries into one MultiGeometry.
    *
-   * @param {import("ol/geom/SimpleGeometry").default[]} geometries An array of ol.geom.geometries;
-   * @returns {import("ol/geom/MultiPoint").default|import("ol/geom/MultiPolygon").default|import("ol/geom/MultiLineString").default} A Multigeometry.
+   * @param {OlGeomSimple[]} geometries An array of ol.geom.geometries;
+   * @returns {OlGeomMultiPoint|OlGeomMultiPolygon|OlGeomMultiLineString|undefined} A Multigeometry.
    */
   static mergeGeometries(geometries) {
     const multiPrefix = GeometryUtil.MULTI_GEOM_PREFIX;
@@ -140,19 +188,19 @@ class GeometryUtil {
       case 'Polygon':
         multiGeom = new OlGeomMultiPolygon([]);
         for (const geom of splittedGeometries) {
-          multiGeom.appendPolygon(/** @type {import("ol/geom/Polygon").default} */ (geom));
+          multiGeom.appendPolygon(/** @type {OlGeomPolygon} */ (geom));
         }
         return multiGeom;
       case 'Point':
         multiGeom = new OlGeomMultiPoint([]);
         for (const geom of splittedGeometries) {
-          multiGeom.appendPoint(/** @type {import("ol/geom/Point").default} */ (geom));
+          multiGeom.appendPoint(/** @type {OlGeomPoint} */ (geom));
         }
         return multiGeom;
       case 'LineString':
         multiGeom = new OlGeomMultiLineString([]);
         for (const geom of splittedGeometries) {
-          multiGeom.appendLineString(/** @type {import("ol/geom/LineString").default} */ (geom));
+          multiGeom.appendLineString(/** @type {OlGeomLineString} */ (geom));
         }
         return multiGeom;
       default:
@@ -164,8 +212,8 @@ class GeometryUtil {
    * Splits an array of geometries (and multi geometries) or a single MultiGeom
    * into an array of single geometries.
    *
-   * @param {import("ol/geom/SimpleGeometry").default|import("ol/geom/SimpleGeometry").default[]} geometries An (array of) ol.geom.geometries;
-   * @returns {Omit<import("ol/geom/SimpleGeometry").default, OlGeomMultiPolygon|OlGeomMultiLineString|OlGeomMultiPoint>[]} An array of geometries.
+   * @param {OlGeomSimple|OlGeomSimple[]} geometries An (array of) ol.geom.geometries;
+   * @returns {Omit<OlGeomSimple, OlGeomMultiPolygon|OlGeomMultiLineString|OlGeomMultiPoint>[]} An array of geometries.
    */
   static separateGeometries(geometries) {
     geometries = Array.isArray(geometries) ? geometries : [geometries];
@@ -187,119 +235,140 @@ class GeometryUtil {
   /**
    * Takes two or more polygons and returns a combined (Multi-)polygon.
    *
-   * @param {import("ol/geom/Geometry").default[] | import("ol/Feature").default[]} polygons An array of ol.Feature
-   *  or ol.geom.Geometry instances of type (Multi-)polygon.
+   * @param {OlFeature<OlGeomPolygon>[]} polygons An array of ol.Feature
+   *  or ol.geom.Geometry instances of type Polygon.
    * @param {string} projection The projection of the input polygons as EPSG code.
    *  Default is to EPSG:3857.
-   * @returns {import("ol/geom/Geometry").default | import("ol/Feature").default} A Feature or Geometry with the
+   * @returns {OlGeomMultiPolygon|OlGeomPolygon|OlFeature<OlGeomMultiPolygon|OlGeomPolygon>|undefined} A Feature or Geometry with the
    * combined area of the (Multi-)polygons.
    */
   static union(polygons, projection = 'EPSG:3857') {
+    const geometries = polygons.map(toGeom);
+    const union = GeometryUtil.unionGeometries(geometries, projection);
+    if (polygons[0] instanceof OlFeature) {
+      return new OlFeature(union);
+    } else {
+      return union;
+    }
+  }
+
+  /**
+   * Takes two or more polygons and returns a combined (Multi-)polygon.
+   *
+   * @param {OlGeomPolygon[]} polygons An array of ol.geom.Geometry instances of type (Multi-)polygon.
+   * @param {string} projection The projection of the input polygons as EPSG code.
+   *  Default is to EPSG:3857.
+   * @returns {OlGeomMultiPolygon|OlGeomPolygon|undefined} A FGeometry with the combined area of the (Multi-)polygons.
+   */
+  static unionGeometries(polygons, projection = 'EPSG:3857') {
     const geoJsonFormat = new OlFormatGeoJSON({
       dataProjection: 'EPSG:4326',
       featureProjection: projection
     });
-    let invalid = false;
-    const geoJsonsFeatures = polygons.map((geometry) => {
-      const feature = geometry instanceof OlFeature
-        ? geometry
-        : new OlFeature({ geometry });
-      if (!['Polygon', 'MultiPolygon'].includes(feature.getGeometry().getType())) {
-        invalid = true;
-      }
-      return geoJsonFormat.writeFeatureObject(feature);
-    });
-    if (invalid) {
-      // Logger.warn('Can only create union of polygons.');
-      return undefined;
-    }
-    const unioned = geoJsonsFeatures.reduce((prev, next) => {
-      return union(/** @type {TurfFeature} */ (prev), /** @type {TurfFeature} */ (next));
-    });
-    const feature = geoJsonFormat.readFeature(unioned);
-    if (polygons[0] instanceof OlFeature) {
-      return feature;
+
+    const geometry = polygons
+      .map(p => geoJsonFormat.writeFeatureObject(new OlFeature(p)))
+      .reduce((prev, next) => {
+        return /** @type {import("geojson").Feature} */ (union(/** @type {TurfFeature} */ (prev), /** @type {TurfFeature} */ (next)));
+      });
+
+    return /** @type {OlGeomMultiPolygon|OlGeomPolygon} */ (geoJsonFormat.readFeature(geometry).getGeometry());
+  }
+
+  /**
+   * Finds the difference between two polygons by clipping the second polygon from the first.
+   *
+   * If both polygons are of type ol.Feature it will return an ol.Feature.
+   * Else it will return an ol.geom.Geometry.
+   *
+   * @param {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>} polygon1 An ol.geom.Geometry or ol.Feature
+   * @param {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>} polygon2 An ol.geom.Geometry or ol.Feature
+   * @param {string} projection The projection of the input polygons as EPSG code.
+   *  Default is to EPSG:3857.
+   *
+   * @returns {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>} A Feature or Geometry with the area
+   *  of polygon1 excluding the area of polygon2.
+   */
+  static difference(polygon1, polygon2, projection = 'EPSG:3857') {
+    if (polygon1 instanceof OlFeature && polygon2 instanceof OlFeature) {
+      return new OlFeature(GeometryUtil.geometryDifference(toGeom(polygon1), toGeom(polygon2), projection));
     } else {
-      return feature.getGeometry();
+      return GeometryUtil.geometryDifference(toGeom(polygon1), toGeom(polygon2), projection);
     }
   }
 
   /**
    * Finds the difference between two polygons by clipping the second polygon from the first.
    *
-   * @param {import("ol/geom/Geometry").default | import("ol/Feature").default} polygon1 An ol.geom.Geometry or ol.Feature
-   * @param {import("ol/geom/Geometry").default | import("ol/Feature").default} polygon2 An ol.geom.Geometry or ol.Feature
+   * @param {OlGeomPolygon|OlGeomMultiPolygon} polygon1 An ol.geom.Geometry
+   * @param {OlGeomPolygon|OlGeomMultiPolygon} polygon2 An ol.geom.Geometry
    * @param {string} projection The projection of the input polygons as EPSG code.
    *  Default is to EPSG:3857.
    *
-   * @returns {import("ol/geom/Geometry").default | import("ol/Feature").default} A Feature or Geometry with the area
-   *  of polygon1 excluding the area of polygon2. The type of the first polygon
-   *  (geometry or feature) determines the return type.
+   * @returns {OlGeomPolygon|OlGeomMultiPolygon} A with the area
+   *  of polygon1 excluding the area of polygon2.
    */
-  static difference(polygon1, polygon2, projection = 'EPSG:3857') {
+  static geometryDifference(polygon1, polygon2, projection = 'EPSG:3857') {
     const geoJsonFormat = new OlFormatGeoJSON({
       dataProjection: 'EPSG:4326',
       featureProjection: projection
     });
-    const feat1 = polygon1 instanceof OlFeature ? polygon1
-      : new OlFeature({
-        geometry: polygon1
-      });
-    const feat2 = polygon2 instanceof OlFeature ? polygon2
-      : new OlFeature({
-        geometry: polygon2
-      });
-    const geojson1 = geoJsonFormat.writeFeatureObject(feat1);
-    const geojson2 = geoJsonFormat.writeFeatureObject(feat2);
+    const geojson1 = geoJsonFormat.writeFeatureObject(new OlFeature(polygon1));
+    const geojson2 = geoJsonFormat.writeFeatureObject(new OlFeature(polygon2));
     const intersection = difference(/** @type {TurfFeature} */ (geojson1), /** @type {TurfFeature} */ (geojson2));
     const feature = geoJsonFormat.readFeature(intersection);
+    return /** @type {OlGeomPolygon|OlGeomMultiPolygon} */ (feature.getGeometry());
+  }
+
+  /**
+   * Takes two polygons and finds their intersection.
+   *
+   * If both polygons are of type ol.Feature it will return an ol.Feature.
+   * Else it will return an ol.geom.Geometry.
+   *
+   * @param {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>} polygon1 An ol.geom.Geometry or ol.Feature
+   * @param {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>} polygon2 An ol.geom.Geometry or ol.Feature
+   * @param {string} projection The projection of the input polygons as EPSG code.
+   *  Default is to EPSG:3857.
+   *
+   * @returns {OlGeomPolygon|OlGeomMultiPolygon|OlFeature<OlGeomPolygon|OlGeomMultiPolygon>|null} A Feature or Geometry with the
+   * shared area of the two polygons or null if the polygons don't intersect.
+   */
+  static intersection(polygon1, polygon2, projection = 'EPSG:3857') {
+    const intersection = GeometryUtil.geometryIntersection(toGeom(polygon1), toGeom(polygon2), projection);
+    if (!intersection) {
+      return null;
+    }
     if (polygon1 instanceof OlFeature && polygon2 instanceof OlFeature) {
-      return feature;
+      return new OlFeature(intersection);
     } else {
-      return feature.getGeometry();
+      return intersection;
     }
   }
 
   /**
    * Takes two polygons and finds their intersection.
    *
-   * If the polygons are of type ol.Feature it will return an ol.Feature.
-   * If the polygons are of type ol.geom.Geometry it will return an ol.geom.Geometry.
-   *
-   * @param {import("ol/geom/Geometry").default | import("ol/Feature").default} polygon1 An ol.geom.Geometry or ol.Feature
-   * @param {import("ol/geom/Geometry").default | import("ol/Feature").default} polygon2 An ol.geom.Geometry or ol.Feature
+   * @param {OlGeomPolygon|OlGeomMultiPolygon} polygon1 An ol.geom.Geometry
+   * @param {OlGeomPolygon|OlGeomMultiPolygon} polygon2 An ol.geom.Geometry
    * @param {string} projection The projection of the input polygons as EPSG code.
    *  Default is to EPSG:3857.
    *
-   * @returns {import("ol/geom/Geometry").default | import("ol/Feature").default} A Feature or Geometry with the
+   * @returns {OlGeomPolygon|OlGeomMultiPolygon|null} A Geometry with the
    * shared area of the two polygons or null if the polygons don't intersect.
    */
-  static intersection(polygon1, polygon2, projection = 'EPSG:3857') {
+  static geometryIntersection(polygon1, polygon2, projection = 'EPSG:3857') {
     const geoJsonFormat = new OlFormatGeoJSON({
       dataProjection: 'EPSG:4326',
       featureProjection: projection
     });
-    const feat1 = polygon1 instanceof OlFeature ? polygon1
-      : new OlFeature({
-        geometry: polygon1
-      });
-    const feat2 = polygon2 instanceof OlFeature ? polygon2
-      : new OlFeature({
-        geometry: polygon2
-      });
-    const geojson1 = geoJsonFormat.writeFeatureObject(feat1);
-    const geojson2 = geoJsonFormat.writeFeatureObject(feat2);
+    const geojson1 = geoJsonFormat.writeFeatureObject(new OlFeature(polygon1));
+    const geojson2 = geoJsonFormat.writeFeatureObject(new OlFeature(polygon2));
     const intersection = intersect(/** @type {TurfFeature} */ (geojson1), /** @type {TurfFeature} */ (geojson2));
     if (!intersection) {
       return null;
     }
-    const feature = geoJsonFormat.readFeature(intersection);
-    if (polygon1 instanceof OlFeature && polygon2 instanceof OlFeature) {
-      return feature;
-    } else {
-      return feature.getGeometry();
-    }
+    return /** @type {OlGeomPolygon|OlGeomMultiPolygon} */ (geoJsonFormat.readFeature(intersection).getGeometry());
   }
-
 }
 export default GeometryUtil;


### PR DESCRIPTION
This PR splits of all functions in the `GeometryUtil` into 2 separate functions. A new function is created that is prefixed or suffixed with `geometry` and accepts only geometries and returns always geometries. This variant is therefore more type-safe. The other function keeps the signature and behavior of the old function but uses internally the new function.