### PR TITLE
feat: use errors instead of the logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
         "@babel/runtime": "^7.17.2",
+        "@types/proj4": "^2.5.2",
         "@types/shpjs": "^3.4.1",
         "babel-jest": "^27.5.1",
         "canvas": "^2.9.0",
@@ -4659,6 +4660,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "node_modules/@types/proj4": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
+      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw==",
       "dev": true
     },
     "node_modules/@types/responselike": {
@@ -19042,6 +19049,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "@types/proj4": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
+      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw==",
       "dev": true
     },
     "@types/responselike": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@babel/runtime": "^7.17.2",
+    "@types/proj4": "^2.5.2",
     "@types/shpjs": "^3.4.1",
     "babel-jest": "^27.5.1",
     "canvas": "^2.9.0",

--- a/src/CapabilitiesUtil/CapabilitiesUtil.js
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.js
@@ -6,7 +6,6 @@ import _get from 'lodash/get';
 import _isFunction from 'lodash/isFunction';
 
 import UrlUtil from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
-import Logger from '@terrestris/base-util/dist/Logger';
 
 import LayerUtil from '../LayerUtil/LayerUtil';
 
@@ -24,22 +23,17 @@ class CapabilitiesUtil {
    * @return {Promise<Object>} An object representing the WMS capabilities.
    */
   static async getWmsCapabilities(capabilitiesUrl) {
-    try {
-      const capabilitiesResponse = await fetch(capabilitiesUrl);
+    const capabilitiesResponse = await fetch(capabilitiesUrl);
 
-      if (!capabilitiesResponse.ok) {
-        Logger.error('Could not get Capabilities');
-        return;
-      }
-
-      const wmsCapabilitiesParser = new OlWMSCapabilities();
-
-      const capabilitiesText = await capabilitiesResponse.text();
-
-      return wmsCapabilitiesParser.read(capabilitiesText);
-    } catch (error) {
-      Logger.error(`Error while reading Capabilities: ${error}`);
+    if (!capabilitiesResponse.ok) {
+      throw new Error('Could not get capabilities.');
     }
+
+    const wmsCapabilitiesParser = new OlWMSCapabilities();
+
+    const capabilitiesText = await capabilitiesResponse.text();
+
+    return wmsCapabilitiesParser.read(capabilitiesText);
   }
 
   /**

--- a/src/GeometryUtil/GeometryUtil.js
+++ b/src/GeometryUtil/GeometryUtil.js
@@ -159,7 +159,7 @@ class GeometryUtil {
    * Merges multiple geometries into one MultiGeometry.
    *
    * @param {OlGeomSimple[]} geometries An array of ol.geom.geometries;
-   * @returns {OlGeomMultiPoint|OlGeomMultiPolygon|OlGeomMultiLineString|undefined} A Multigeometry.
+   * @returns {OlGeomMultiPoint|OlGeomMultiPolygon|OlGeomMultiLineString} A Multigeometry.
    */
   static mergeGeometries(geometries) {
     const multiPrefix = GeometryUtil.MULTI_GEOM_PREFIX;
@@ -171,8 +171,7 @@ class GeometryUtil {
       }
     });
     if (mixedGeometryTypes) {
-      // Logger.warn('Can not merge mixed geometries into one multigeometry.');
-      return undefined;
+      throw new Error('Can not merge mixed geometries into one multigeometry.');
     }
 
     // split all multi-geometries to simple ones if passed geometries are
@@ -203,8 +202,6 @@ class GeometryUtil {
           multiGeom.appendLineString(/** @type {OlGeomLineString} */ (geom));
         }
         return multiGeom;
-      default:
-        return undefined;
     }
   }
 
@@ -239,7 +236,7 @@ class GeometryUtil {
    *  or ol.geom.Geometry instances of type Polygon.
    * @param {string} projection The projection of the input polygons as EPSG code.
    *  Default is to EPSG:3857.
-   * @returns {OlGeomMultiPolygon|OlGeomPolygon|OlFeature<OlGeomMultiPolygon|OlGeomPolygon>|undefined} A Feature or Geometry with the
+   * @returns {OlGeomMultiPolygon|OlGeomPolygon|OlFeature<OlGeomMultiPolygon|OlGeomPolygon>} A Feature or Geometry with the
    * combined area of the (Multi-)polygons.
    */
   static union(polygons, projection = 'EPSG:3857') {
@@ -258,7 +255,7 @@ class GeometryUtil {
    * @param {OlGeomPolygon[]} polygons An array of ol.geom.Geometry instances of type (Multi-)polygon.
    * @param {string} projection The projection of the input polygons as EPSG code.
    *  Default is to EPSG:3857.
-   * @returns {OlGeomMultiPolygon|OlGeomPolygon|undefined} A FGeometry with the combined area of the (Multi-)polygons.
+   * @returns {OlGeomMultiPolygon|OlGeomPolygon} A FGeometry with the combined area of the (Multi-)polygons.
    */
   static unionGeometries(polygons, projection = 'EPSG:3857') {
     const geoJsonFormat = new OlFormatGeoJSON({

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -2,8 +2,6 @@ import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceWMTS from 'ol/source/WMTS';
 
-import Logger from '@terrestris/base-util/dist/Logger';
-
 import CapabilitiesUtil from '../CapabilitiesUtil/CapabilitiesUtil';
 
 /**
@@ -17,7 +15,7 @@ class LayerUtil {
    * Returns the configured URL of the given layer.
    *
    * @param {import("../types").WMSOrWMTSLayer} layer The layer to get the URL from.
-   * @returns The layer URL.
+   * @returns {string} The layer URL.
    */
   static getLayerUrl = layer => {
     const layerSource = layer.getSource();
@@ -29,8 +27,6 @@ class LayerUtil {
       layerUrl = layerSource.getUrl();
     } else if (layerSource instanceof OlSourceWMTS) {
       layerUrl = layerSource.getUrls()[0];
-    } else {
-      Logger.error('The given source type is not supported.');
     }
 
     return layerUrl;
@@ -48,8 +44,7 @@ class LayerUtil {
 
     if (!capabilities || !capabilities.Capability || !capabilities.Capability.Layer ||
       !capabilities.Capability.Layer.Layer) {
-      Logger.error('Unexpected format of the Capabilities.');
-      return;
+      throw new Error('Unexpected format of the Capabilities.');
     }
 
     const layerName = layer.getSource().getParams().LAYERS;
@@ -59,15 +54,13 @@ class LayerUtil {
     });
 
     if (!layers || layers.length === 0) {
-      Logger.error('Could not find the desired layer in the Capabilities.');
-      return;
+      throw new Error('Could not find the desired layer in the Capabilities.');
     }
 
     const extent = layers[0].EX_GeographicBoundingBox;
 
     if (!extent || extent.length !== 4) {
-      Logger.error('No extent set in the Capabilities.');
-      return;
+      throw new Error('No extent set in the Capabilities.');
     }
 
     return extent;

--- a/src/MapUtil/MapUtil.js
+++ b/src/MapUtil/MapUtil.js
@@ -267,7 +267,7 @@ export class MapUtil {
    *  - ol.source.TileWms (with url configured)
    *  - ol.source.ImageWms (with url configured)
    *
-   * @param {import("../types").WMSLayer} layer The layer that you want to have a legendUrlfor.
+   * @param {import("../types").WMSLayer} layer The layer that you want to have a legendUrl for.
    * @param {Object} extraParams
    * @return {string|undefined} The getLegendGraphicUrl.
    */

--- a/src/MapUtil/MapUtil.spec.js
+++ b/src/MapUtil/MapUtil.spec.js
@@ -6,14 +6,11 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlLayerImage from 'ol/layer/Image';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
-import OlSourceTileJson from 'ol/source/TileJSON';
 import OlFeature from 'ol/Feature';
 import OlGeomPoint from 'ol/geom/Point';
 import OlLayerGroup from 'ol/layer/Group';
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
-
-import Logger from '@terrestris/base-util/dist/Logger';
 
 import TestUtil from '../TestUtil';
 
@@ -48,17 +45,6 @@ describe('MapUtil', () => {
   describe('#getInteractionsByName', () => {
     it('is defined', () => {
       expect(MapUtil.getInteractionsByName).toBeDefined();
-    });
-
-    it('needs to be called with a map instance', () => {
-      const logSpy = jest.spyOn(Logger, 'debug');
-
-      let returnedInteractions = MapUtil.getInteractionsByName(null, 'BVB!');
-
-      expect(logSpy).toHaveBeenCalled();
-      expect(returnedInteractions).toHaveLength(0);
-
-      logSpy.mockRestore();
     });
 
     it('returns an empty array if no interaction candidate is found', () => {
@@ -98,17 +84,6 @@ describe('MapUtil', () => {
   describe('#getInteractionsByClass', () => {
     it('is defined', () => {
       expect(MapUtil.getInteractionsByClass).toBeDefined();
-    });
-
-    it('needs to be called with a map instance', () => {
-      const logSpy = jest.spyOn(Logger, 'debug');
-
-      let returnedInteractions = MapUtil.getInteractionsByClass(null, OlInteractionDragRotateAndZoom);
-
-      expect(logSpy).toHaveBeenCalled();
-      expect(returnedInteractions).toHaveLength(0);
-
-      logSpy.mockRestore();
     });
 
     it('returns an empty array if no interaction candidate is found', () => {
@@ -359,17 +334,6 @@ describe('MapUtil', () => {
       map.setLayerGroup(layerGroup);
     });
 
-    it('Logs an error and returns an empty array on invalid argument', () => {
-      const logSpy = jest.spyOn(Logger, 'error');
-      const got = MapUtil.getAllLayers();
-
-      expect(got).toBeInstanceOf(Array);
-      expect(got).toHaveLength(0);
-      expect(logSpy).toHaveBeenCalled();
-
-      logSpy.mockRestore();
-    });
-
     it('returns a flat list of all layers (map passed)', () => {
       const got = MapUtil.getAllLayers(map);
 
@@ -466,7 +430,6 @@ describe('MapUtil', () => {
     let layer1;
     let layer2;
     let layer3;
-    let layer4;
 
     beforeEach(() => {
       layer1 = new OlLayerTile({
@@ -486,13 +449,6 @@ describe('MapUtil', () => {
         })
       });
       layer3 = new OlLayerTile({
-        name: 'Food insecurity',
-        source: new OlSourceTileJson({
-          url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
-          crossOrigin: 'anonymous'
-        })
-      });
-      layer4 = new OlLayerTile({
         name: 'OSM-WMS',
         source: new OlSourceTileWMS({
           urls: [
@@ -503,24 +459,6 @@ describe('MapUtil', () => {
           serverType: 'geoserver'
         })
       });
-    });
-
-    it('logs an error if called without a layer', () => {
-      const logSpy = jest.spyOn(Logger, 'error');
-      const legendUrl = MapUtil.getLegendGraphicUrl();
-      expect(legendUrl).toBeUndefined();
-      expect(logSpy).toHaveBeenCalled();
-      expect(logSpy).toHaveBeenCalledWith('No layer passed to MapUtil.getLegendGraphicUrl.');
-
-      logSpy.mockRestore();
-    });
-
-    it('logs a warning if called with an unsupported layersource', () => {
-      const logSpy = jest.spyOn(Logger, 'warn');
-      const legendUrl = MapUtil.getLegendGraphicUrl(layer3);
-      expect(legendUrl).toBeUndefined();
-      expect(logSpy).toHaveBeenCalledWith('Source of "Food insecurity" is currently not supported by MapUtil.getLegendGraphicUrl.');
-      logSpy.mockRestore();
     });
 
     describe('returns a getLegendGraphicUrl from a given layer', () => {
@@ -567,7 +505,7 @@ describe('MapUtil', () => {
     });
 
     it('works as expected when layer URL contains params', () => {
-      const legendUrl = MapUtil.getLegendGraphicUrl(layer4);
+      const legendUrl = MapUtil.getLegendGraphicUrl(layer3);
       const numQuestionMarks = (legendUrl.match(/\?/g) || []).length;
       const containsParams = /humpty=dumpty/.test(legendUrl);
       expect(numQuestionMarks).toEqual(1);
@@ -819,11 +757,6 @@ describe('MapUtil', () => {
 
     it('is defined', () => {
       expect(MapUtil.zoomToFeatures).toBeDefined();
-    });
-
-    it('returns undefined if no map is given', () => {
-      const got = MapUtil.zoomToFeatures(null, features);
-      expect(got).toBe(undefined);
     });
 
     it('fits the view extent to the extent of the given features', () => {

--- a/src/ProjectionUtil/ProjectionUtil.js
+++ b/src/ProjectionUtil/ProjectionUtil.js
@@ -79,6 +79,7 @@ export class ProjectionUtil {
    *   as well or not. Default is true.
    */
   static initProj4DefinitionMappings(customCrsMappings, useDefaultMappings = true) {
+    /** @type {Record<string, string>} */
     let proj4CrsMappings = {};
 
     if (useDefaultMappings) {


### PR DESCRIPTION
BREAKING CHANGE: Many functions no longer return `undefined` and log errors to the console, but throw them instead. Affected functions are:
* `getWmsCapabilities`
* `getWmsCapabilitiesByLayer`
* `parseWmsCapabilities`
* `getExtentForLayer`
* `mergeGeometries`

```
const val = CapabilitiesUtil.getWmsCapabilities(...)
if (val === undefined) {
  // ...
}
// ->
try {
  const val = CapabilitiesUtil.getWmsCapabilities(...)
} catch (e) {
  // ...
}
```

Also several functions do not test for correct input parameters anymore as the typescript types take care of this now.
Affected methods:
* `getInteractionsByName`
* `getInteractionsByClass`
* `getAllLayers`
* `getLegendGraphicUrl`