### PR TITLE
introduce OL map to inkmap spec util method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
         "@types/geojson": "^7946.0.8",
+        "geostyler-openlayers-parser": "^3.0.2",
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.8",
         "proj4": "^2.7.5",
@@ -2764,7 +2765,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2773,7 +2773,6 @@
       "version": "13.23.1",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.23.1.tgz",
       "integrity": "sha512-C6wh8A/5EdsgzhL6y6yl464VCQNIxK0yjrpnvCvchcFe3sNK2RbBw/J9u3m+p8Y6S6MsGuSMt3AkGAXOKMYweQ==",
-      "dev": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -2853,14 +2852,12 @@
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -2907,8 +2904,7 @@
     "node_modules/@petamoriken/float16": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.2.tgz",
-      "integrity": "sha512-zZnksXtFBqvONcXWuAtSWrl3YXaDbU2ArRCCuzM42mP0GBJclD6e0GC3zEemmrjiMSOHcLPyRC4vOnAsnomJIw==",
-      "dev": true
+      "integrity": "sha512-zZnksXtFBqvONcXWuAtSWrl3YXaDbU2ArRCCuzM42mP0GBJclD6e0GC3zEemmrjiMSOHcLPyRC4vOnAsnomJIw=="
     },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -6240,8 +6236,7 @@
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "node_modules/cssfontparser": {
       "version": "1.2.1",
@@ -7614,11 +7609,31 @@
         "quickselect": "^2.0.0"
       }
     },
+    "node_modules/geostyler-openlayers-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "dependencies": {
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/geostyler-style": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/geotiff": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
       "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
-      "dev": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -8093,7 +8108,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10725,8 +10739,7 @@
     "node_modules/json-stringify-pretty-compact": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -10842,8 +10855,7 @@
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "dev": true
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11348,7 +11360,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -11429,8 +11440,7 @@
     "node_modules/mapbox-to-css-font": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
-      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow==",
-      "dev": true
+      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow=="
     },
     "node_modules/marked": {
       "version": "4.0.16",
@@ -11657,8 +11667,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -12622,7 +12631,6 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.1.tgz",
       "integrity": "sha512-sIcUWkGud3Y2gT3TJubSHlkyMXiPVh1yxfCPHxmY8+qtm79bB9oRnei9xHVIbRRG0Ro6Ldp5E+BMVSvYCxSpaA==",
-      "dev": true,
       "dependencies": {
         "geotiff": "^2.0.2",
         "ol-mapbox-style": "^7.1.1",
@@ -12638,7 +12646,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
       "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
-      "dev": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.1",
@@ -12648,14 +12655,12 @@
     "node_modules/ol/node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "node_modules/ol/node_modules/rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
       "dependencies": {
         "quickselect": "^2.0.0"
       }
@@ -13175,8 +13180,7 @@
     "node_modules/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
-      "dev": true
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -13193,8 +13197,7 @@
     "node_modules/parse-headers": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
-      "dev": true
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -13275,7 +13278,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -13446,8 +13448,7 @@
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -13871,7 +13872,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -13972,8 +13972,7 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
@@ -14216,7 +14215,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
       "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14225,7 +14223,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
       "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14234,7 +14231,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
       "dependencies": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -15303,14 +15299,12 @@
     "node_modules/web-worker": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
-      "dev": true
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
-      "dev": true
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -15539,8 +15533,7 @@
     "node_modules/xml-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
-      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ==",
-      "dev": true
+      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -15569,8 +15562,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -17551,14 +17543,12 @@
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "dev": true
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
       "version": "13.23.1",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.23.1.tgz",
       "integrity": "sha512-C6wh8A/5EdsgzhL6y6yl464VCQNIxK0yjrpnvCvchcFe3sNK2RbBw/J9u3m+p8Y6S6MsGuSMt3AkGAXOKMYweQ==",
-      "dev": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -17618,14 +17608,12 @@
     "@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
-      "dev": true
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=",
-      "dev": true
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -17663,8 +17651,7 @@
     "@petamoriken/float16": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.2.tgz",
-      "integrity": "sha512-zZnksXtFBqvONcXWuAtSWrl3YXaDbU2ArRCCuzM42mP0GBJclD6e0GC3zEemmrjiMSOHcLPyRC4vOnAsnomJIw==",
-      "dev": true
+      "integrity": "sha512-zZnksXtFBqvONcXWuAtSWrl3YXaDbU2ArRCCuzM42mP0GBJclD6e0GC3zEemmrjiMSOHcLPyRC4vOnAsnomJIw=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -20311,8 +20298,7 @@
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs=",
-      "dev": true
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "cssfontparser": {
       "version": "1.2.1",
@@ -21361,11 +21347,28 @@
         }
       }
     },
+    "geostyler-openlayers-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
+      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "requires": {
+        "geostyler-style": "^5.0.2",
+        "lodash": "^4.17.21"
+      }
+    },
+    "geostyler-style": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-5.1.0.tgz",
+      "integrity": "sha512-AJzQBomzuTGr01uRYvu7bocJTBB6vrgBdxsIoSHDATbnNF07XnAtsrbkjXlMsKaRnbqE2MGLhQqBmBx6C2Gubg==",
+      "requires": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
+      }
+    },
     "geotiff": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
       "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
-      "dev": true,
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -21722,8 +21725,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -23674,8 +23676,7 @@
     "json-stringify-pretty-compact": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -23772,8 +23773,7 @@
     "lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "dev": true
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "leven": {
       "version": "3.1.0",
@@ -24161,7 +24161,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -24223,8 +24222,7 @@
     "mapbox-to-css-font": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
-      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow==",
-      "dev": true
+      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow=="
     },
     "marked": {
       "version": "4.0.16",
@@ -24394,8 +24392,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -25151,7 +25148,6 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.1.tgz",
       "integrity": "sha512-sIcUWkGud3Y2gT3TJubSHlkyMXiPVh1yxfCPHxmY8+qtm79bB9oRnei9xHVIbRRG0Ro6Ldp5E+BMVSvYCxSpaA==",
-      "dev": true,
       "requires": {
         "geotiff": "^2.0.2",
         "ol-mapbox-style": "^7.1.1",
@@ -25162,14 +25158,12 @@
         "quickselect": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-          "dev": true
+          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
         },
         "rbush": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
           "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-          "dev": true,
           "requires": {
             "quickselect": "^2.0.0"
           }
@@ -25180,7 +25174,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
       "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
-      "dev": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.1",
@@ -25572,8 +25565,7 @@
     "pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
-      "dev": true
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -25587,8 +25579,7 @@
     "parse-headers": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw==",
-      "dev": true
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -25651,7 +25642,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
       "requires": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -25785,8 +25775,7 @@
     "protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "psl": {
       "version": "1.8.0",
@@ -26116,7 +26105,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -26184,8 +26172,7 @@
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
       "version": "6.6.7",
@@ -26384,20 +26371,17 @@
     "sort-asc": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "dev": true
+      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
     },
     "sort-desc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "dev": true
+      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
     },
     "sort-object": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dev": true,
       "requires": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -27231,14 +27215,12 @@
     "web-worker": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
-      "dev": true
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
-      "dev": true
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
     },
     "webidl-conversions": {
       "version": "7.0.0",
@@ -27409,8 +27391,7 @@
     "xml-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
-      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ==",
-      "dev": true
+      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -27433,8 +27414,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
         "@types/geojson": "^7946.0.8",
-        "geostyler-openlayers-parser": "^3.0.2",
+        "geostyler-openlayers-parser": "^3.1.0",
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.8",
         "proj4": "^2.7.5",
@@ -7610,16 +7610,22 @@
       }
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "dependencies": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/geostyler-style": {
       "version": "5.1.0",
@@ -21348,12 +21354,20 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "requires": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
       }
     },
     "geostyler-style": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@terrestris/base-util": "^1.0.1",
     "@turf/turf": "^6.5.0",
     "@types/geojson": "^7946.0.8",
-    "geostyler-openlayers-parser": "^3.0.2",
+    "geostyler-openlayers-parser": "^3.1.0",
     "lodash": "^4.17.21",
     "polygon-splitter": "^0.0.8",
     "proj4": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@terrestris/base-util": "^1.0.1",
     "@turf/turf": "^6.5.0",
     "@types/geojson": "^7946.0.8",
+    "geostyler-openlayers-parser": "^3.0.2",
     "lodash": "^4.17.21",
     "polygon-splitter": "^0.0.8",
     "proj4": "^2.7.5",

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -2,6 +2,8 @@ import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceWMTS from 'ol/source/WMTS';
 
+import Logger from '@terrestris/base-util/dist/Logger';
+
 import CapabilitiesUtil from '../CapabilitiesUtil/CapabilitiesUtil';
 
 /**
@@ -66,6 +68,46 @@ class LayerUtil {
 
     return /** @type {[number, number, number, number]} */ (extent);
   }
+
+  /**
+   * Returns all attributions as text joined by a separator.
+   *
+   * @param {import("ol/layer/Layer").default} layer The layer to get the attributions from.
+   * @param {string} separator The separator separating multiple attributions.
+   * @returns {string} The attributions.
+   */
+  static getLayerAttributionsText = (layer, separator = ', ') => {
+    const attributionsFn = layer.getSource()?.getAttributions();
+    // @ts-ignore
+    const attributions = attributionsFn ? attributionsFn(undefined) : null;
+
+    let attributionString;
+    if (Array.isArray(attributions)) {
+      attributionString = attributions.map(LayerUtil.getTextFromHtml).join(separator);
+    } else {
+      attributionString = attributions ? LayerUtil.getTextFromHtml(attributions) : '';
+    }
+    return attributionString;
+  };
+
+
+  /**
+   * Converts a html string into text using DOMParser.
+   *
+   * Credits: https://stackoverflow.com/questions/822452/strip-html-from-text-javascript/47140708#47140708.
+   *
+   * @param {string} html The html to convert.
+   * @returns {string} The output text. Returns an empty string if parsing fails.
+   */
+  static getTextFromHtml = (html) => {
+    try {
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return doc.body.textContent || '';
+    } catch (error) {
+      Logger.error(error);
+      return '';
+    }
+  };
 
 }
 

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -90,7 +90,6 @@ class LayerUtil {
     return attributionString;
   };
 
-
   /**
    * Converts a html string into text using DOMParser.
    *

--- a/src/MapUtil/MapUtil.js
+++ b/src/MapUtil/MapUtil.js
@@ -8,7 +8,6 @@ import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 
 import UrlUtil from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
-import Logger from '@terrestris/base-util/dist/Logger';
 
 import FeatureUtil from '../FeatureUtil/FeatureUtil';
 import LayerUtil from '../LayerUtil/LayerUtil';
@@ -424,23 +423,17 @@ export class MapUtil {
     const layerPromises = olMap.getAllLayers()
       .map(LayerUtil.mapOlLayerToInkmap);
 
+    const responses = await Promise.all(layerPromises);
+    const layers = responses.filter(l => l !== null);
+    const config = {
+      layers: layers,
+      center: centerLonLat,
+      scale: scale,
+      projection: projection
+    };
+    // ignore typecheck because responses.filter(l => l !== null) is not recognized properly
     // @ts-ignore
-    return Promise.all(layerPromises)
-      .then((responses) => {
-        // ignore typecheck because responses.filter(l => l !== null) is not recognized properly
-        const layers = responses.filter(l => l !== null);
-        const config = {
-          layers: layers,
-          center: centerLonLat,
-          scale: scale,
-          projection: projection
-        };
-        return Promise.resolve(config);
-      })
-      .catch((error) => {
-        Logger.error(error);
-        return Promise.reject();
-      });
+    return config;
   }
 
 }

--- a/src/types.js
+++ b/src/types.js
@@ -7,4 +7,102 @@
  *  |import("ol/source/WMTS")>} WMSOrWMTSLayer
  */
 
+/**
+ * @typedef {{
+ *   layers: InkmapLayer[],
+ *   size?: number[],
+ *   center: [number, number],
+ *   dpi: number,
+ *   scale: number,
+ *   scalebar: boolean | ScaleBarSpec,
+ *   northArrow: boolean | string,
+ *   projection: string,
+ *   projectionDefinitions?: InkmapProjectionDefinition[],
+ *   attributions: boolean | 'top-left' | 'bottom-left' | 'bottom-right' | 'top-right'
+ *  }} InkmapPrintSpec
+ */
+
+/**
+ * @typedef {InkmapWmsLayer | InkmapWmtsLayer | InkmapGeoJsonLayer | InkmapWfsLayer | InkmapOsmLayer} InkmapLayer
+ */
+
+/**
+ * @typedef {{
+ *   position: 'bottom-left' | 'bottom-right',
+ *   units: string
+ *  }} ScaleBarSpec
+ */
+
+/**
+ * @typedef {{
+ *   type: 'WMS',
+ *   url: string,
+ *   opacity?: number,
+ *   attribution?: string,
+ *   layer: string,
+ *   tiled?: boolean
+ *  }} InkmapWmsLayer
+ */
+
+/**
+ * @typedef {{
+ *   type: 'WMTS',
+ *   url: string,
+ *   opacity?: number,
+ *   attribution?: string,
+ *   layer?: string,
+ *   projection?: string,
+ *   matrixSet?: string,
+ *   tileGrid?: any,
+ *   format?: string,
+ *   requestEncoding?: string
+ *  }} InkmapWmtsLayer
+ */
+
+/**
+ * @typedef {{
+ *   type: 'GeoJSON',
+ *   attribution?: string,
+ *   style: any,
+ *   geojson: any
+ *  }} InkmapGeoJsonLayer
+ */
+
+/**
+ * @typedef {{
+ *   type: 'WFS',
+ *   url: string,
+ *   attribution?: string,
+ *   layer?: string,
+ *   projection?: string
+ *  }} InkmapWfsLayer
+ */
+
+/**
+ * @typedef {{
+ *   layers: string,
+ *   type: 'XYZ';
+ *   url: string,
+ *   opacity?: number,
+ *   attribution?: string,
+ *   layer?: string,
+ *   tiled?: boolean,
+ *   projection?: string,
+ *   matrixSet?: string,
+ *   tileGrid?: any,
+ *   style?: any,
+ *   format?: string,
+ *   requestEncoding?: string,
+ *   geojson?: any
+ *  }} InkmapOsmLayer
+ */
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   bbox: [number, number, number, number],
+ *   proj4: string
+ *  }} InkmapProjectionDefinition
+ */
+
 export default undefined;


### PR DESCRIPTION
Introduces two util methods for ol maps / layers:

* convert OpenLayers map to inkmap print spec: `generatePrintConfig(olMap)`
* convert OpenLayers layer to inkmap layer spec: `mapOlLayerToInkmap(olLayer)`

Also adds a new util method which generates a text output from OpenLayers attributions: `getLayerAttributionsText(htmlString)`

This makes the react-geo component cleaner: See https://github.com/terrestris/react-geo/pull/2608#pullrequestreview-1010250259

@terrestris/devs Please review