### PR TITLE
print: support layer name and legend URL

### DIFF
--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -85,7 +85,11 @@ class LayerUtil {
    */
   static async mapOlLayerToInkmap(olLayer) {
     const source = olLayer.getSource();
-    const opacity = olLayer.getVisible() ? olLayer.getOpacity() : 0;
+    if (!olLayer.getVisible) {
+      // do not include invisible layers
+      return null;
+    }
+    const opacity = olLayer.getOpacity();
 
     const attributionString = LayerUtil.getLayerAttributionsText(olLayer);
 

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -85,11 +85,13 @@ class LayerUtil {
    */
   static async mapOlLayerToInkmap(olLayer) {
     const source = olLayer.getSource();
-    if (!olLayer.getVisible) {
+    if (!olLayer.getVisible()) {
       // do not include invisible layers
       return null;
     }
     const opacity = olLayer.getOpacity();
+    const legendUrl = olLayer.get('legendUrl');
+    const layerName = olLayer.get('name');
 
     const attributionString = LayerUtil.getLayerAttributionsText(olLayer);
 
@@ -97,20 +99,24 @@ class LayerUtil {
       const tileWmsLayer = {
         type: 'WMS',
         url: source.getUrls()?.[0] ?? '',
-        opacity: opacity,
+        opacity,
         attribution: attributionString,
         layer: source.getParams()?.LAYERS,
-        tiled: true
+        tiled: true,
+        legendUrl,
+        layerName
       };
       return /** @type {import("../types").InkmapWmsLayer} */ (tileWmsLayer);
     } else if (source instanceof OlSourceImageWMS) {
       const imageWmsLayer = {
         type: 'WMS',
         url: source.getUrl() ?? '',
-        opacity: opacity,
+        opacity,
         attribution: attributionString,
         layer: source.getParams()?.LAYERS,
-        tiled: false
+        tiled: false,
+        legendUrl,
+        layerName
       };
       return /** @type {import("../types").InkmapWmsLayer} */ (imageWmsLayer);
     } else if (source instanceof OlSourceWMTS) {
@@ -131,28 +137,34 @@ class LayerUtil {
         layer: source.getLayer(),
         projection: source.getProjection().getCode(),
         matrixSet: source.getMatrixSet(),
-        tileGrid: tileGrid,
+        tileGrid,
         format: source.getFormat(),
-        opacity: opacity,
-        attribution: attributionString
+        opacity,
+        attribution: attributionString,
+        legendUrl,
+        layerName
       };
       return /** @type {import("../types").InkmapWmtsLayer} */ (wmtsLayer);
     } else if (source instanceof OlSourceOSM) {
       const osmLayer = {
         type: 'XYZ',
         url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        opacity: opacity,
+        opacity,
         attribution: '© OpenStreetMap (www.openstreetmap.org)',
-        tiled: true
+        tiled: true,
+        legendUrl,
+        layerName
       };
       return /** @type {import("../types").InkmapOsmLayer} */ (osmLayer);
     } else if (source instanceof OlSourceStamen) {
       const stamenLayer = {
         type: 'XYZ',
         url: source.getUrls()?.[0],
-        opacity: opacity,
+        opacity,
         attribution: attributionString,
-        tiled: true
+        tiled: true,
+        legendUrl,
+        layerName
       };
       return /** @type {import("../types").InkmapLayer} */ (stamenLayer);
     } else if (source instanceof OlSourceVector) {
@@ -160,9 +172,11 @@ class LayerUtil {
       const parser = new OpenLayersParser();
       const geojsonLayerConfig = {
         type: 'GeoJSON',
-        geojson: geojson,
+        geojson,
         attribution: attributionString,
-        style: undefined
+        style: undefined,
+        legendUrl,
+        layerName
       };
 
       let olStyle = null;

--- a/src/types.js
+++ b/src/types.js
@@ -40,7 +40,9 @@
  *   opacity?: number,
  *   attribution?: string,
  *   layer: string,
- *   tiled?: boolean
+ *   tiled?: boolean,
+ *   legendUrl?: string,
+ *   name?: string
  *  }} InkmapWmsLayer
  */
 
@@ -55,7 +57,9 @@
  *   matrixSet?: string,
  *   tileGrid?: any,
  *   format?: string,
- *   requestEncoding?: string
+ *   requestEncoding?: string,
+ *   legendUrl?: string,
+ *   name?: string
  *  }} InkmapWmtsLayer
  */
 
@@ -64,7 +68,9 @@
  *   type: 'GeoJSON',
  *   attribution?: string,
  *   style: any,
- *   geojson: any
+ *   geojson: any,
+ *   legendUrl?: string,
+ *   name?: string
  *  }} InkmapGeoJsonLayer
  */
 
@@ -74,13 +80,14 @@
  *   url: string,
  *   attribution?: string,
  *   layer?: string,
- *   projection?: string
+ *   projection?: string,
+ *   legendUrl?: string,
+ *   name?: string
  *  }} InkmapWfsLayer
  */
 
 /**
  * @typedef {{
- *   layers: string,
  *   type: 'XYZ';
  *   url: string,
  *   opacity?: number,
@@ -88,12 +95,8 @@
  *   layer?: string,
  *   tiled?: boolean,
  *   projection?: string,
- *   matrixSet?: string,
- *   tileGrid?: any,
- *   style?: any,
- *   format?: string,
- *   requestEncoding?: string,
- *   geojson?: any
+ *   legendUrl?: string,
+ *   name?: string
  *  }} InkmapOsmLayer
  */
 


### PR DESCRIPTION
- removes not visible layer from print spec 
- reads name and legendUrl from layer and passes it to print spec

@terrestris/devs Please review