### PR TITLE
support for custom attributes in permalink

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run test && npm run build:dist && npm run build:declarations",
     "build:declarations": "tsc --emitDeclarationOnly",
     "build:docs": "npm run clean:docs && typedoc",
-    "build:dist": "npm run clean:dist && BABEL_ENV=production babel src --out-dir dist --copy-files --ignore **/*.spec.js --extensions \".ts,.js\"",
+    "build:dist": "npm run clean:dist && BABEL_ENV=production babel src --out-dir dist --copy-files --ignore **/*.spec.js --extensions \".ts,.js\" && npm run build:declarations",
     "clean:dist": "rimraf ./dist/*",
     "clean:docs": "rimraf build/docs",
     "coveralls": "cat coverage/lcov.info | coveralls",


### PR DESCRIPTION
Adds a new parameter `customAttributes` to PermalinkUtil::getLink. This will save given attributes in the permalink if they are present. Example:

```js
PermalinkUtil.getLink(
  map,
  ';',
  identifierFunction,
  filterFunction,
  ['isExternalLayer', 'layerConfig']
);
```

Also returns customLayerAttributes in `applyLink` to allow usage of attributes that can not be restored directly on the map.

@terrestris/devs Please review.