### PR TITLE
Add support for custom fetch options while requesting WMS Capabilities

### DIFF
--- a/src/CapabilitiesUtil/CapabilitiesUtil.js
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.js
@@ -20,10 +20,12 @@ class CapabilitiesUtil {
    * Fetches and parses the WMS Capabilities document for the given URL.
    *
    * @param {string} capabilitiesUrl Url to WMS capabilities document.
+   * @param {RequestInit} fetchOpts Optional fetch options to make use of
+   *                                while requesting the Capabilities.
    * @return {Promise<any>} An object representing the WMS capabilities.
    */
-  static async getWmsCapabilities(capabilitiesUrl) {
-    const capabilitiesResponse = await fetch(capabilitiesUrl);
+  static async getWmsCapabilities(capabilitiesUrl, fetchOpts = {}) {
+    const capabilitiesResponse = await fetch(capabilitiesUrl, fetchOpts);
 
     if (!capabilitiesResponse.ok) {
       throw new Error('Could not get capabilities.');
@@ -40,12 +42,14 @@ class CapabilitiesUtil {
    * Fetches and parses the WMS Capabilities document for the given layer.
    *
    * @param {import("../types").WMSLayer} layer The layer to the get the Capabilites for.
+   * @param {RequestInit} fetchOpts Optional fetch options to make use of
+   *                                while requesting the Capabilities.
    * @return {Promise<any>} An object representing the WMS capabilities.
    */
-  static async getWmsCapabilitiesByLayer(layer) {
+  static async getWmsCapabilitiesByLayer(layer, fetchOpts = {}) {
     const capabilitiesUrl = this.getCapabilitiesUrl(layer);
 
-    return await this.getWmsCapabilities(capabilitiesUrl);
+    return await this.getWmsCapabilities(capabilitiesUrl, fetchOpts);
   }
 
   /**

--- a/src/LayerUtil/LayerUtil.js
+++ b/src/LayerUtil/LayerUtil.js
@@ -47,10 +47,12 @@ class LayerUtil {
    * appropriate Capabilities document.
    *
    * @param {import("../types").WMSLayer} layer
+   * @param {RequestInit} fetchOpts Optional fetch options to make use of
+   *                                while requesting the Capabilities.
    * @returns {Promise<[number, number, number, number]>} The extent of the layer.
    */
-  static async getExtentForLayer(layer) {
-    const capabilities = await CapabilitiesUtil.getWmsCapabilitiesByLayer(layer);
+  static async getExtentForLayer(layer, fetchOpts = {}) {
+    const capabilities = await CapabilitiesUtil.getWmsCapabilitiesByLayer(layer, fetchOpts);
 
     if (!capabilities?.Capability?.Layer?.Layer) {
       throw new Error('Unexpected format of the Capabilities.');


### PR DESCRIPTION
Adds support for passing custom fetch options. This can become handy if someone wants to pass additional (authorization) headers or similiar.

Please review @terrestris/devs.