### PR TITLE
Improve OlSource check for MapUtil GetLegendGraphic

### DIFF
--- a/src/MapUtil/MapUtil.ts
+++ b/src/MapUtil/MapUtil.ts
@@ -266,7 +266,7 @@ export class MapUtil {
    * @param {OlLayerTile<OlSourceTileWMS> | OlLayerImage<OlSourceImageWMS>} layer The layer that you want to have a
    * legendUrl for.
    * @param {Object} extraParams
-   * @return {string | undefined} The getLegendGraphicUrl.
+   * @return {string} The getLegendGraphicUrl.
    */
   static getLegendGraphicUrl(
     layer: OlLayerTile<OlSourceTileWMS> | OlLayerImage<OlSourceImageWMS>,

--- a/src/MapUtil/MapUtil.ts
+++ b/src/MapUtil/MapUtil.ts
@@ -266,7 +266,7 @@ export class MapUtil {
    * @param {OlLayerTile<OlSourceTileWMS> | OlLayerImage<OlSourceImageWMS>} layer The layer that you want to have a
    * legendUrl for.
    * @param {Object} extraParams
-   * @return {string} The getLegendGraphicUrl.
+   * @return {string | undefined} The getLegendGraphicUrl.
    */
   static getLegendGraphicUrl(
     layer: OlLayerTile<OlSourceTileWMS> | OlLayerImage<OlSourceImageWMS>,
@@ -276,8 +276,8 @@ export class MapUtil {
   ): string {
     const source = layer.getSource();
 
-    if (!source) {
-      throw new Error('Layer has no source.');
+    if (!(source instanceof OlSourceTileWMS || source instanceof OlSourceImageWMS)) {
+      return;
     }
 
     const url = (source instanceof OlSourceTileWMS

--- a/src/MapUtil/MapUtil.ts
+++ b/src/MapUtil/MapUtil.ts
@@ -277,7 +277,7 @@ export class MapUtil {
     const source = layer.getSource();
 
     if (!(source instanceof OlSourceTileWMS || source instanceof OlSourceImageWMS)) {
-      return;
+      throw new Error('Layer has no or unexpected source.');
     }
 
     const url = (source instanceof OlSourceTileWMS

--- a/src/MapUtil/MapUtil.ts
+++ b/src/MapUtil/MapUtil.ts
@@ -276,7 +276,7 @@ export class MapUtil {
   ): string {
     const source = layer.getSource();
 
-    if (!(source instanceof OlSourceTileWMS || source instanceof OlSourceImageWMS)) {
+    if (!source || !(source instanceof OlSourceTileWMS || source instanceof OlSourceImageWMS)) {
       throw new Error('Layer has no or unexpected source.');
     }
 


### PR DESCRIPTION
This improves the check for source types for the `getLegendGraphicUrl` function.

@dnlkoch please review.