### PR TITLE
feat: add custom print params for wms

### DIFF
--- a/src/LayerUtil/InkmapTypes.ts
+++ b/src/LayerUtil/InkmapTypes.ts
@@ -7,6 +7,7 @@ export type InkmapWmsLayer = {
   tiled?: boolean;
   legendUrl?: string;
   layerName?: string;
+  customParams?: any;
 };
 
 export type InkmapWmtsLayer = {

--- a/src/LayerUtil/LayerUtil.ts
+++ b/src/LayerUtil/LayerUtil.ts
@@ -111,7 +111,10 @@ class LayerUtil {
     const opacity = olLayer.getOpacity();
     const legendUrl = olLayer.get('legendUrl');
     const layerName = olLayer.get('name');
-    const time = source.getParams().TIME;
+    let time;
+    if (LayerUtil.isOlSourceTileWMS(source) || LayerUtil.isOlSourceImageWMS(source)) {
+      time = source.getParams().TIME;
+    }
 
     // todo: introduce config object which hold possible additional configurations
     const attributionString = LayerUtil.getLayerAttributionsText(olLayer, ' ,', true);
@@ -127,7 +130,7 @@ class LayerUtil {
         legendUrl,
         layerName,
         customParams: {
-          time
+          ...(time && { time })
         }
       };
     } else if (LayerUtil.isOlSourceImageWMS(source)) {
@@ -141,7 +144,7 @@ class LayerUtil {
         legendUrl,
         layerName,
         customParams: {
-          time
+          ...(time && { time })
         }
       };
     } else if (LayerUtil.isOlSourceWMTS(source)) {

--- a/src/LayerUtil/LayerUtil.ts
+++ b/src/LayerUtil/LayerUtil.ts
@@ -26,6 +26,7 @@ interface UnknownOlSource {
   getUrls?: any;
   attribution?: any;
   getLegendUrl?: any;
+  getParams?: any;
 }
 
 /**
@@ -110,6 +111,7 @@ class LayerUtil {
     const opacity = olLayer.getOpacity();
     const legendUrl = olLayer.get('legendUrl');
     const layerName = olLayer.get('name');
+    const time = source.getParams().TIME;
 
     // todo: introduce config object which hold possible additional configurations
     const attributionString = LayerUtil.getLayerAttributionsText(olLayer, ' ,', true);
@@ -123,7 +125,10 @@ class LayerUtil {
         layer: source.getParams()?.LAYERS,
         tiled: true,
         legendUrl,
-        layerName
+        layerName,
+        customParams: {
+          time
+        }
       };
     } else if (LayerUtil.isOlSourceImageWMS(source)) {
       return {
@@ -134,7 +139,10 @@ class LayerUtil {
         layer: source.getParams()?.LAYERS,
         tiled: false,
         legendUrl,
-        layerName
+        layerName,
+        customParams: {
+          time
+        }
       };
     } else if (LayerUtil.isOlSourceWMTS(source)) {
       const olTileGrid = source.getTileGrid();


### PR DESCRIPTION
This adds current time dimension of wms layer source to the print config (via customParams).  
Thanks for help @LukasLohoff 

@terrestris/devs please check.