### PR TITLE
feat: use node 18 for semantic release

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -89,4 +89,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx -p node@v18-lts -c "npx semantic-release"


### PR DESCRIPTION
Semantic release requires >= node 18, cf. latest failed action https://github.com/terrestris/ol-util/blob/master/.github/workflows/on-push-master.yml#L46

@terrestris/devs 
