### PR TITLE
Reintroduces the use of propertyNames

### DIFF
--- a/src/WfsFilterUtil/WfsFilterUtil.spec.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.spec.ts
@@ -36,6 +36,7 @@ describe('WfsFilterUtil', () => {
     featureNS: 'test',
     featureTypes: [featureType],
     featurePrefix: 'test',
+    propertyNames: ['testAttribute', 'anotherTestAttribute'],
     attributeDetails: {
       featureType: {}
     }

--- a/src/WfsFilterUtil/WfsFilterUtil.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.ts
@@ -133,8 +133,6 @@ class WfsFilterUtil {
 
     const requests = featureTypes?.map((featureType: string): any => {
       const filter = WfsFilterUtil.createWfsFilter(featureType, searchTerm, attributeDetails);
-      const filterPropertyNames = Object.keys(attributeDetails[featureType]);
-
       const wfsFormatOpts: WriteGetFeatureOptions = {
         featureNS,
         featurePrefix,
@@ -145,12 +143,8 @@ class WfsFilterUtil {
         srsName
       };
 
-      if (!_isNil(filterPropertyNames)) {
-        wfsFormatOpts.propertyNames = filterPropertyNames;
-      }
       if (!_isNil(propertyNames)) {
-        wfsFormatOpts.propertyNames =
-          wfsFormatOpts?.propertyNames?.concat(propertyNames);
+        wfsFormatOpts.propertyNames = propertyNames;
       }
       if (!_isNil(filter)) {
         wfsFormatOpts.filter = filter;

--- a/src/WfsFilterUtil/WfsFilterUtil.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.ts
@@ -47,6 +47,7 @@ export type SearchConfig = {
   srsName?: string;
   wfsFormatOptions?: string;
   attributeDetails: AttributeDetails;
+  propertyNames?: string[];
 };
 
 /**
@@ -126,12 +127,14 @@ class WfsFilterUtil {
       maxFeatures,
       outputFormat,
       srsName,
-      attributeDetails
+      attributeDetails,
+      propertyNames
     } = searchConfig;
 
     const requests = featureTypes?.map((featureType: string): any => {
       const filter = WfsFilterUtil.createWfsFilter(featureType, searchTerm, attributeDetails);
-      const propertyNames = Object.keys(attributeDetails[featureType]);
+      const filterPropertyNames = Object.keys(attributeDetails[featureType]);
+
       const wfsFormatOpts: WriteGetFeatureOptions = {
         featureNS,
         featurePrefix,
@@ -142,8 +145,12 @@ class WfsFilterUtil {
         srsName
       };
 
-      if (!_isNil(propertyNames)) {
-        wfsFormatOpts.propertyNames = propertyNames;
+      if (!_isNil(filterPropertyNames)) {
+        wfsFormatOpts.propertyNames = filterPropertyNames;
+
+        if (!_isNil(propertyNames)) {
+          wfsFormatOpts.propertyNames = filterPropertyNames.concat(propertyNames);
+        }
       }
       if (!_isNil(filter)) {
         wfsFormatOpts.filter = filter;

--- a/src/WfsFilterUtil/WfsFilterUtil.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.ts
@@ -147,10 +147,10 @@ class WfsFilterUtil {
 
       if (!_isNil(filterPropertyNames)) {
         wfsFormatOpts.propertyNames = filterPropertyNames;
-
-        if (!_isNil(propertyNames)) {
-          wfsFormatOpts.propertyNames = filterPropertyNames.concat(propertyNames);
-        }
+      }
+      if (!_isNil(propertyNames)) {
+        wfsFormatOpts.propertyNames =
+          wfsFormatOpts?.propertyNames?.concat(propertyNames);
       }
       if (!_isNil(filter)) {
         wfsFormatOpts.filter = filter;


### PR DESCRIPTION
This PR reintroduces optional `propertyNames` into SearchConfig as its part of the SearchConfig in react-geo and is used to create a combined property names array. This allows the request to get additional properties, which aren't configured in the `attributeDetails` (e.g. the geometry).

@terrestris/devs please review