### PR TITLE
fix: wfs query append

### DIFF
--- a/src/WfsFilterUtil/WfsFilterUtil.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.ts
@@ -157,17 +157,12 @@ class WfsFilterUtil {
     if (_isNil(requests)) {
       return;
     }
-    const request = requests[0] as Element;
-
-    requests.forEach((req: any) => {
-      if (req !== request) {
-        const query = req.contains('Query');
-        if (query !== null) {
-          request.append(query);
-        }
+    const request = requests[0];
+    requests.forEach((req, idx) => {
+      if (idx !== 0 && req.querySelector('Query')) {
+        request.appendChild(req.querySelector('Query'));
       }
     });
-
     return request;
   }
 }


### PR DESCRIPTION
This fixes the appending of WFS Query Nodes.
As we are using Nodes here, the `contains` method did not work as expected.

@terrestris/devs please review