### PR TITLE
fix: moveFeature in AnimateUtil

### DIFF
--- a/src/AnimateUtil/AnimateUtil.ts
+++ b/src/AnimateUtil/AnimateUtil.ts
@@ -1,3 +1,4 @@
+import _isFunction from 'lodash/isFunction';
 import _isNil from 'lodash/isNil';
 import OlFeature from 'ol/Feature';
 import OlGeometry from 'ol/geom/Geometry';
@@ -66,7 +67,11 @@ class AnimateUtil {
         geometry.translate(deltaX, deltaY);
 
         if (style) {
-          vectorContext.setStyle(style);
+          if (_isFunction(style)) {
+            vectorContext.setStyle(style(featureToMove));
+          } else {
+            vectorContext.setStyle(style);
+          }
         }
         vectorContext.drawGeometry(geometry);
 


### PR DESCRIPTION
This makes sure that the `setStyle` method always receives a style, as style functions are not supported as argument anymore.

Fixes https://github.com/terrestris/react-geo/issues/3105

@terrestris/devs please review