### PR TITLE
fix: fix wfs filter builder

### DIFF
--- a/src/WfsFilterUtil/WfsFilterUtil.ts
+++ b/src/WfsFilterUtil/WfsFilterUtil.ts
@@ -136,7 +136,7 @@ class WfsFilterUtil {
       const wfsFormatOpts: WriteGetFeatureOptions = {
         featureNS,
         featurePrefix,
-        featureTypes,
+        featureTypes: [featureType],
         geometryName,
         maxFeatures,
         outputFormat,


### PR DESCRIPTION
Properly pass a feature type to WFS format options builder.

Please review @terrestris/devs 