### PR TITLE
Check for capabilities structure

### DIFF
--- a/src/CapabilitiesUtil/CapabilitiesUtil.ts
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.ts
@@ -90,8 +90,16 @@ class CapabilitiesUtil {
     const layersInCapabilities = _get(capabilities, 'Capability.Layer.Layer');
     const wmsGetMapConfig = _get(capabilities, 'Capability.Request.GetMap');
     const wmsGetFeatureInfoConfig = _get(capabilities, 'Capability.Request.GetFeatureInfo');
-    const getMapUrl = _get(wmsGetMapConfig, 'DCPType[0].HTTP.Get.OnlineResource');
-    const getFeatureInfoUrl = _get(wmsGetFeatureInfoConfig, 'DCPType[0].HTTP.Get.OnlineResource');
+    let getMapUrl: any;
+    let getFeatureInfoUrl: any;
+
+    if (Array.isArray(wmsGetMapConfig.DCPType) && Array.isArray(wmsGetFeatureInfoConfig.DCPType)) {
+      getMapUrl = _get(wmsGetMapConfig, 'DCPType[0].HTTP.Get.OnlineResource');
+      getFeatureInfoUrl = _get(wmsGetFeatureInfoConfig, 'DCPType[0].HTTP.Get.OnlineResource');
+    } else {
+      getMapUrl = _get(wmsGetMapConfig, 'DCPType.HTTP.Get.OnlineResource.xlink:href');
+      getFeatureInfoUrl = _get(wmsGetFeatureInfoConfig, 'DCPType.HTTP.Get.OnlineResource.xlink:href');
+    }
 
     return layersInCapabilities.map((layerObj: any) => {
       const title = _get(layerObj, 'Attribution.Title');


### PR DESCRIPTION
Adds a check for the structure of the capabilities
- they used to be organized in a array but are now changed to a object

I also had to adjust the _get function since the output needs to be a string. 
