### PR TITLE
chore: allow broader version range for OpenLayers peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "node-pre-gyp": "^0.17.0",
         "np": "^8.0.1",
-        "ol": "^7.2.2",
+        "ol": "7.4.0",
         "rimraf": "^5.0.0",
         "semantic-release": "^21.0.0",
         "shp-write": "^0.3.2",
@@ -61,7 +61,7 @@
         "npm": ">=7"
       },
       "peerDependencies": {
-        "ol": "^7.1"
+        "ol": "^7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -19462,9 +19462,9 @@
       }
     },
     "node_modules/ol": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-7.5.1.tgz",
-      "integrity": "sha512-CFXDhO8YdQt7I+zwrGYSONo/ZM2oLr7vUvxqpLEUyy+USaQjUeE8L6FBOWIPboopGVhnSVYd5hdEirn9ifKBZQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.4.0.tgz",
+      "integrity": "sha512-bgBbiah694HhC0jt8ptEFNRXwgO8d6xWH3G97PCg4bmn9Li5nLLbi59oSrvqUI6VPVwonPQF1YcqJymxxyMC6A==",
       "dependencies": {
         "earcut": "^2.2.3",
         "geotiff": "^2.0.7",
@@ -23357,9 +23357,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "node-pre-gyp": "^0.17.0",
     "np": "^8.0.1",
-    "ol": "^7.2.2",
+    "ol": "7.4.0",
     "rimraf": "^5.0.0",
     "semantic-release": "^21.0.0",
     "shp-write": "^0.3.2",
@@ -96,6 +96,6 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "ol": "^7.1"
+    "ol": "^7"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: set peer dependency for OpenLayers to ^7

In addition, the dev dependency version has been increased to version 7.4.0.

Plz review @terrestris/devs 