### PR TITLE
fix!: added getLength decimal precision for non geodesic map

### DIFF
--- a/src/MeasureUtil/MeasureUtil.ts
+++ b/src/MeasureUtil/MeasureUtil.ts
@@ -27,6 +27,7 @@ class MeasureUtil {
    * @return {number} The length of line in meters.
    */
   static getLength(line: OlGeomLineString, map: OlMap, geodesic: boolean = true, radius: number = 6371008.8): number {
+    const decimalPrecision = Math.pow(10, 6);
     if (geodesic) {
       const opts = {
         projection: map.getView().getProjection().getCode(),
@@ -34,7 +35,7 @@ class MeasureUtil {
       };
       return getLength(line, opts);
     } else {
-      return Math.round(line.getLength() * 100) / 100;
+      return Math.round(line.getLength() * decimalPrecision) / decimalPrecision;
     }
   }
 

--- a/src/MeasureUtil/MeasureUtil.ts
+++ b/src/MeasureUtil/MeasureUtil.ts
@@ -22,12 +22,20 @@ class MeasureUtil {
    * @param {OlMap} map An OlMap.
    * @param {boolean} geodesic Is the measurement geodesic (default is true).
    * @param {number} radius Sphere radius. By default, the radius of the earth
-   *                        is used (Clarke 1866 Authalic Sphere, 6371008.8).
+   *                    	is used (Clarke 1866 Authalic Sphere, 6371008.8).
+   * @param {number} decimalPrecision Set the decimal precision before rounding
+   *						length value on non-geodesic map (default value 6)
    *
    * @return {number} The length of line in meters.
    */
-  static getLength(line: OlGeomLineString, map: OlMap, geodesic: boolean = true, radius: number = 6371008.8): number {
-    const decimalPrecision = Math.pow(10, 6);
+  static getLength(
+  	line: OlGeomLineString,
+  	map: OlMap,
+  	geodesic: boolean = true,
+  	radius: number = 6371008.8,
+  	decimalPrecision: number = 6
+  ): number {
+    const decimalHelper = Math.pow(10, decimalPrecision);
     if (geodesic) {
       const opts = {
         projection: map.getView().getProjection().getCode(),
@@ -35,7 +43,7 @@ class MeasureUtil {
       };
       return getLength(line, opts);
     } else {
-      return Math.round(line.getLength() * decimalPrecision) / decimalPrecision;
+      return Math.round(line.getLength() * decimalHelper) / decimalHelper;
     }
   }
 

--- a/src/MeasureUtil/MeasureUtil.ts
+++ b/src/MeasureUtil/MeasureUtil.ts
@@ -22,9 +22,9 @@ class MeasureUtil {
    * @param {OlMap} map An OlMap.
    * @param {boolean} geodesic Is the measurement geodesic (default is true).
    * @param {number} radius Sphere radius. By default, the radius of the earth
-   *                    	is used (Clarke 1866 Authalic Sphere, 6371008.8).
-   * @param {number} decimalPrecision Set the decimal precision before rounding
-   *						length value on non-geodesic map (default value 6)
+   *                    	  is used (Clarke 1866 Authalic Sphere, 6371008.8).
+   * @param {number} decimalPrecision Set the decimal precision on length value
+   *                    	  for non-geodesic map (default value 6)
    *
    * @return {number} The length of line in meters.
    */


### PR DESCRIPTION
When we use the line measurement tools on a non-geodesic map with cm detail, the precision is truncated by the rounding at the getLength method level. 
As a result, the lengths displayed are rounded to the decimetre.
In this pull request, I propose a stronger quoeficient to get a more accurate result.
I've based on the quotient used in the area calculation, which I think is relevant.
Best regards