### PR TITLE
Move TypeScript to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.11",
         "proj4": "^2.9.0",
-        "shpjs": "^4.0.4",
-        "typescript": "^5.2.2"
+        "shpjs": "^4.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.22.11",
@@ -52,6 +51,7 @@
         "semantic-release": "^22.0.5",
         "shp-write": "^0.3.2",
         "typedoc": "^0.25.0",
+        "typescript": "^5.2.2",
         "watch": "1.0.2",
         "whatwg-fetch": "^3.6.18"
       },
@@ -19723,6 +19723,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "lodash": "^4.17.21",
     "polygon-splitter": "^0.0.11",
     "proj4": "^2.9.0",
-    "shpjs": "^4.0.4",
-    "typescript": "^5.2.2"
+    "shpjs": "^4.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -91,6 +90,7 @@
     "semantic-release": "^22.0.5",
     "shp-write": "^0.3.2",
     "typedoc": "^0.25.0",
+    "typescript": "^5.2.2",
     "watch": "1.0.2",
     "whatwg-fetch": "^3.6.18"
   },


### PR DESCRIPTION
while browsing through `package.json` I noticed that TypeScript is listed under `dependencies`, but it should be listed under `devDependencies`. 