### PR TITLE
Fix getExtentForLayer

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -31,5 +31,8 @@ jobs:
     - name: Install dependencies ⏬
       run: npm install
 
+    - name: Run tests 🩺
+      run: npm test
+
     - name: Build artifacts 🏗️
       run: npm run build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "npm": ">=9"
   },
   "scripts": {
-    "build": "npm run test && npm run build:dist",
+    "build": "npm run build:dist",
     "build:docs": "npm run clean:docs && typedoc ./src/**/*",
     "build:dist": "npm run clean:dist && tsc -p tsconfig.json",
     "clean:dist": "rimraf ./dist/*",

--- a/src/LayerUtil/LayerUtil.spec.ts
+++ b/src/LayerUtil/LayerUtil.spec.ts
@@ -75,45 +75,98 @@ describe('LayerUtil', () => {
     });
 
     describe('#getExtentForLayer', () => {
-      it('returns the extent of the given layer for GetCapabilities request version 1.3.0', async () => {
-        const layer = new OlLayerTile({
-          source: new OlSourceTileWMS({
-            url: 'https://ows.terrestris.de/osm-gray/service?',
-            params: {
-              LAYERS: 'OSM-WMS'
+      it('returns the extent of the given layer for GetCapabilities request version 1.3.0 (multiple layers)',
+        async () => {
+          const layer = new OlLayerTile({
+            source: new OlSourceTileWMS({
+              url: 'https://ows.terrestris.de/osm-gray/service?',
+              params: {
+                LAYERS: 'OSM-WMS'
+              }
+            }),
+            properties: {
+              name: 'OSM-WMS'
             }
-          }),
-          properties: {
-            name: 'OSM-WMS'
-          }
-        });
+          });
 
-        const mockImpl = jest.fn();
-        mockImpl.mockReturnValue({
-          Capability: {
-            Layer: {
-              Layer: [{
-                Name: 'OSM-WMS',
-                // eslint-disable-next-line camelcase
-                EX_GeographicBoundingBox: {
-                  westBoundLongitude: 1,
-                  southBoundLatitude: 2,
-                  eastBoundLongitude: 3,
-                  northBoundLatitude: 4
+          const mockImpl = jest.fn();
+          mockImpl.mockReturnValue({
+            Capability: {
+              Layer: {
+                Layer: [{
+                  Name: 'OSM-WMS',
+                  // eslint-disable-next-line camelcase
+                  EX_GeographicBoundingBox: {
+                    westBoundLongitude: 1,
+                    southBoundLatitude: 2,
+                    eastBoundLongitude: 3,
+                    northBoundLatitude: 4
+                  }
+                }, {
+                  Name: 'Peter',
+                  // eslint-disable-next-line camelcase
+                  EX_GeographicBoundingBox: {
+                    westBoundLongitude: 5,
+                    southBoundLatitude: 6,
+                    eastBoundLongitude: 7,
+                    northBoundLatitude: 8
+                  }
+                }]
+              }
+            }
+          });
+          const getWmsCapabilitiesByLayerSpy = jest.spyOn(CapabilitiesUtil,
+            'getWmsCapabilitiesByLayer').mockImplementation(mockImpl);
+
+          const extent = await LayerUtil.getExtentForLayer(layer);
+
+          expect(extent).toEqual([1, 2, 3, 4]);
+
+          getWmsCapabilitiesByLayerSpy.mockRestore();
+        }
+      );
+
+      it('returns the extent of the given layer for GetCapabilities request version 1.3.0 (single layer)',
+        async () => {
+          const layer = new OlLayerTile({
+            source: new OlSourceTileWMS({
+              url: 'https://ows.terrestris.de/osm-gray/service?',
+              params: {
+                LAYERS: 'OSM-WMS'
+              }
+            }),
+            properties: {
+              name: 'OSM-WMS'
+            }
+          });
+
+          const mockImpl = jest.fn();
+          mockImpl.mockReturnValue({
+            Capability: {
+              Layer: {
+                Layer: {
+                  Name: 'OSM-WMS',
+                  // eslint-disable-next-line camelcase
+                  EX_GeographicBoundingBox: {
+                    westBoundLongitude: 1,
+                    southBoundLatitude: 2,
+                    eastBoundLongitude: 3,
+                    northBoundLatitude: 4
+                  }
                 }
-              }]
+              }
             }
-          }
-        });
-        const getWmsCapabilitiesByLayerSpy = jest.spyOn(CapabilitiesUtil,
-          'getWmsCapabilitiesByLayer').mockImplementation(mockImpl);
+          });
+          const getWmsCapabilitiesByLayerSpy = jest.spyOn(CapabilitiesUtil,
+            'getWmsCapabilitiesByLayer').mockImplementation(mockImpl);
 
-        const extent = await LayerUtil.getExtentForLayer(layer);
+          const extent = await LayerUtil.getExtentForLayer(layer);
 
-        expect(extent).toEqual([1, 2, 3, 4]);
+          expect(extent).toEqual([1, 2, 3, 4]);
 
-        getWmsCapabilitiesByLayerSpy.mockRestore();
-      });
+          getWmsCapabilitiesByLayerSpy.mockRestore();
+        }
+      );
 
       it('returns the extent of the given layer for GetCapabilities request version 1.1.1', async () => {
         const layer = new OlLayerTile({

--- a/src/LayerUtil/LayerUtil.ts
+++ b/src/LayerUtil/LayerUtil.ts
@@ -73,15 +73,19 @@ class LayerUtil {
   ): Promise<OlExtent> {
     const capabilities = await CapabilitiesUtil.getWmsCapabilitiesByLayer(layer, fetchOpts);
 
-    const capabilitiesLayer = capabilities?.Capability?.Layer?.Layer;
+    let layerNodes = capabilities?.Capability?.Layer?.Layer;
 
-    if (!capabilitiesLayer) {
+    if (!layerNodes) {
       throw new Error('Unexpected format of the Capabilities.');
+    }
+
+    if (!Array.isArray(layerNodes)) {
+      layerNodes = [layerNodes];
     }
 
     const layerName = layer.getSource()?.getParams().LAYERS;
     const version = layer.getSource()?.getParams().VERSION || '1.3.0';
-    const layers = capabilitiesLayer.filter((l: any) => {
+    const layers = layerNodes.filter((l: any) => {
       return l.Name === layerName;
     });
 


### PR DESCRIPTION
Fixes `getExtenForLayer` if the response contains only one layer.