### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A set of helper classes for working with OpenLayers
 npm i @terrestris/ol-util
 ```
 
+Be aware that ol-util uses a ESM build, so make sure your downstream application's bundler includes it when transpiling.
+
 ## API Documentation
 
 * Latest: [https://terrestris.github.io/ol-util/latest/index.html](https://terrestris.github.io/ol-util/latest/index.html)


### PR DESCRIPTION
BREAKING CHANGE: ol-util now produces a ESM build, so downstream apps need to include it in their bundler when transpiling for the browser.

@terrestris/devs Please review.