### PR TITLE
fix: fixes the function so it accepts packages that do not return an array

### DIFF
--- a/src/CapabilitiesUtil/CapabilitiesUtil.ts
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.ts
@@ -110,7 +110,6 @@ class CapabilitiesUtil {
     if (!(layersInCapabilities instanceof Array)) {
       layersInCapabilities = [layersInCapabilities];
     }
-    console.log(layersInCapabilities, layersInCapabilities instanceof Array);
 
     return layersInCapabilities.map((layerObj: any) => {
       const title = _get(layerObj, 'Attribution.Title');

--- a/src/CapabilitiesUtil/CapabilitiesUtil.ts
+++ b/src/CapabilitiesUtil/CapabilitiesUtil.ts
@@ -92,7 +92,7 @@ class CapabilitiesUtil {
     proxyFn?: (proxyUrl: string) => string
   ): OlLayerImage<OlSourceImageWMS>[] {
     const wmsVersion = _get(capabilities, 'version');
-    const layersInCapabilities = _get(capabilities, 'Capability.Layer.Layer');
+    let layersInCapabilities = _get(capabilities, 'Capability.Layer.Layer');
     const wmsGetMapConfig = _get(capabilities, 'Capability.Request.GetMap');
     const wmsGetFeatureInfoConfig = _get(capabilities, 'Capability.Request.GetFeatureInfo');
 
@@ -106,6 +106,11 @@ class CapabilitiesUtil {
       getMapUrl = _get(wmsGetMapConfig, 'DCPType.HTTP.Get.OnlineResource.href');
       getFeatureInfoUrl = _get(wmsGetFeatureInfoConfig, 'DCPType.HTTP.Get.OnlineResource.href');
     }
+
+    if (!(layersInCapabilities instanceof Array)) {
+      layersInCapabilities = [layersInCapabilities];
+    }
+    console.log(layersInCapabilities, layersInCapabilities instanceof Array);
 
     return layersInCapabilities.map((layerObj: any) => {
       const title = _get(layerObj, 'Attribution.Title');


### PR DESCRIPTION
In case `layerInCapabilities` is not an Array but an object the `.map()` function would fail since the parameters were wrong. This PR fixes this problem by adding a simple yet effective way to solve this issue. Since the returned data type of `layerInCapabilities` is either an array or an object, we can check if it's an Array, if not we transform it into an array with the length of one. This avoids major code refactoring.  