### PR TITLE
fix: use id property as fallback when getId() is undefined

### DIFF
--- a/src/FeatureUtil/FeatureUtil.ts
+++ b/src/FeatureUtil/FeatureUtil.ts
@@ -123,7 +123,7 @@ class FeatureUtil {
 
     // Fallback if no feature attribute is found.
     if (!resolved) {
-      resolved = `${feature.getId()}`;
+      resolved = `${feature.getId() ?? feature.get('id')}`;
     }
 
     if (!leaveAsUrl) {


### PR DESCRIPTION
See title

PLz review @terrestris/devs 
